### PR TITLE
Subrootpaths

### DIFF
--- a/subrootpaths_test.go
+++ b/subrootpaths_test.go
@@ -25,7 +25,7 @@ func TestArgValidation(t *testing.T) {
 		{input: pathSpan{squareSize: 1, startNode: 0, length: 1}, want: srpNotPowerOf2},
 		{input: pathSpan{squareSize: 20, startNode: 0, length: 1}, want: srpNotPowerOf2},
 		{input: pathSpan{squareSize: 4, startNode: 0, length: 17}, want: srpPastSquareSize},
-		{input: pathSpan{squareSize: 4, startNode: 0, length: 0}, want: srpInvalidShareSize},
+		{input: pathSpan{squareSize: 4, startNode: 0, length: 0}, want: srpInvalidShareCount},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
This PR adds a function `GetSubrootPaths` to generate the minimal set of paths that define the set of subroots in the Namespace Merkle Tree which span a set of shares.

This is required in order to verify a PayForMessage transaction when accepting a new block that you didn't produce, and for fraud proofs.