### PR TITLE
nmt.go: export Min/MaxNamespace functions so we can use them in celestia-node

### DIFF
--- a/nmt.go
+++ b/nmt.go
@@ -373,14 +373,14 @@ type leafRange struct {
 	start, end uint64
 }
 
-// minNamespace parses the minimum namespace id from a given hash
-func minNamespace(hash []byte, size namespace.IDSize) []byte {
+// MinNamespace parses the minimum namespace id from a given hash
+func MinNamespace(hash []byte, size namespace.IDSize) []byte {
 	min := make([]byte, 0, size)
 	return append(min, hash[:size]...)
 }
 
-// maxNamespace parses the maximum namespace id from a given hash
-func maxNamespace(hash []byte, size namespace.IDSize) []byte {
+// MaxNamespace parses the maximum namespace id from a given hash
+func MaxNamespace(hash []byte, size namespace.IDSize) []byte {
 	max := make([]byte, 0, size)
 	return append(max, hash[size:size*2]...)
 }

--- a/nmt_test.go
+++ b/nmt_test.go
@@ -55,8 +55,8 @@ func ExampleNamespacedMerkleTree() {
 	// compute the root
 	root := tree.Root()
 	// the root's min/max namespace is the min and max namespace of all leaves:
-	minNS := minNamespace(root, tree.NamespaceSize())
-	maxNS := maxNamespace(root, tree.NamespaceSize())
+	minNS := MinNamespace(root, tree.NamespaceSize())
+	maxNS := MaxNamespace(root, tree.NamespaceSize())
 	if bytes.Equal(minNS, namespace.ID{0}) {
 		fmt.Printf("Min namespace: %x\n", minNS)
 	}

--- a/proof.go
+++ b/proof.go
@@ -98,8 +98,8 @@ func NewAbsenceProof(proofStart, proofEnd int, proofNodes [][]byte, leafHash []b
 // is complete and no leaf of that namespace was left out in the proof.
 func (proof Proof) VerifyNamespace(h hash.Hash, nID namespace.ID, data [][]byte, root []byte) bool {
 	nth := NewNmtHasher(h, nID.Size(), proof.isMaxNamespaceIDIgnored)
-	min := namespace.ID(minNamespace(root, nID.Size()))
-	max := namespace.ID(maxNamespace(root, nID.Size()))
+	min := namespace.ID(MinNamespace(root, nID.Size()))
+	max := namespace.ID(MaxNamespace(root, nID.Size()))
 	if nID.Size() != min.Size() || nID.Size() != max.Size() {
 		// conflicting namespace sizes
 		return false
@@ -185,7 +185,7 @@ func (proof Proof) verifyLeafHashes(nth *Hasher, verifyCompleteness bool, nID na
 	if verifyCompleteness {
 		// leftSubtrees contains the subtree roots upto [0, r.Start)
 		for _, subtree := range leftSubtrees {
-			leftSubTreeMax := maxNamespace(subtree, nth.NamespaceSize())
+			leftSubTreeMax := MaxNamespace(subtree, nth.NamespaceSize())
 			if nID.LessOrEqual(namespace.ID(leftSubTreeMax)) {
 				return false
 			}
@@ -193,7 +193,7 @@ func (proof Proof) verifyLeafHashes(nth *Hasher, verifyCompleteness bool, nID na
 		// rightSubtrees only contains the subtrees after [0, r.Start)
 		rightSubtrees := proof.nodes
 		for _, subtree := range rightSubtrees {
-			rightSubTreeMin := minNamespace(subtree, nth.NamespaceSize())
+			rightSubTreeMin := MinNamespace(subtree, nth.NamespaceSize())
 			if namespace.ID(rightSubTreeMin).LessOrEqual(nID) {
 				return false
 			}


### PR DESCRIPTION
This PR exports the `MinNamespace` and `MaxNamespace` functions so that we can use them in the `celestia-node` repo instead of directly copying the functionality.