### PR TITLE
Verify inclusion proofs with multiple leaves

### DIFF
--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/celestiaorg/nmt"
 	"github.com/celestiaorg/nmt/namespace"
-	"github.com/google/gofuzz"
+	fuzz "github.com/google/gofuzz"
 )
 
 func TestFuzzProveVerifyNameSpace(t *testing.T) {
@@ -72,7 +72,7 @@ func TestFuzzProveVerifyNameSpace(t *testing.T) {
 				if err != nil {
 					t.Fatalf("error on Prove(%v): %v", i, err)
 				}
-				if ok := singleItemProof.VerifyInclusion(hash, data[i][:size], data[i][size:], treeRoot); !ok {
+				if ok := singleItemProof.VerifyInclusion(hash, data[i][:size], [][]byte{data[i][size:]}, treeRoot); !ok {
 					t.Fatalf("expected VerifyInclusion() == true; data = %#v; proof = %#v", data[i], singleItemProof)
 				}
 				leafIdx++

--- a/nmt_test.go
+++ b/nmt_test.go
@@ -277,7 +277,7 @@ func TestNamespacedMerkleTree_ProveNamespace_Ranges_And_Verify(t *testing.T) {
 					if err != nil {
 						t.Fatalf("unexpected error on Prove(): %v", err)
 					}
-					gotChecksOut := gotSingleProof.VerifyInclusion(sha256.New(), data.ID, data.Data, n.Root())
+					gotChecksOut := gotSingleProof.VerifyInclusion(sha256.New(), data.ID, [][]byte{data.Data}, n.Root())
 					if !gotChecksOut {
 						t.Errorf("Proof.VerifyInclusion() gotChecksOut: %v, want: true", gotChecksOut)
 					}
@@ -467,7 +467,7 @@ func TestIgnoreMaxNamespace(t *testing.T) {
 				if err != nil {
 					t.Fatalf("ProveNamespace() unexpected error: %v", err)
 				}
-				if !singleProof.VerifyInclusion(hash, d.NamespaceID(), d.Data(), tree.Root()) {
+				if !singleProof.VerifyInclusion(hash, d.NamespaceID(), [][]byte{d.Data()}, tree.Root()) {
 					t.Errorf("VerifyInclusion() failed on data: %#v with index: %v", d, idx)
 				}
 				if gotIgnored := singleProof.IsMaxNamespaceIDIgnored(); gotIgnored != tc.ignoreMaxNamespace {

--- a/proof.go
+++ b/proof.go
@@ -210,10 +210,7 @@ func (proof Proof) VerifyInclusion(h hash.Hash, nid namespace.ID, data [][]byte,
 	nth := NewNmtHasher(h, nid.Size(), proof.isMaxNamespaceIDIgnored)
 	hashes := make([][]byte, len(data))
 	for i, d := range data {
-		leafData := append(append(
-			make([]byte, 0, len(d)+len(nid)),
-			nid...),
-			d...)
+		leafData := append(append(make([]byte, 0, len(d)+len(nid)), nid...), d...)
 		hashes[i] = nth.HashLeaf(leafData)
 	}
 

--- a/proof.go
+++ b/proof.go
@@ -209,7 +209,7 @@ func (proof Proof) verifyLeafHashes(nth *Hasher, verifyCompleteness bool, nID na
 // VerifyInclusion checks that the inclusion proof is valid by using leaf data
 // and the provided proof to regenerate and compare the root. Note that the leaf
 // data should not contain the prefixed namespace, unlike the tree.Push method,
-// which takes prefixed data
+// which takes prefixed data. All leaves implicitly have the same namespace ID: `nid`.
 func (proof Proof) VerifyInclusion(h hash.Hash, nid namespace.ID, leaves [][]byte, root []byte) bool {
 	nth := NewNmtHasher(h, nid.Size(), proof.isMaxNamespaceIDIgnored)
 	hashes := make([][]byte, len(leaves))

--- a/proof.go
+++ b/proof.go
@@ -206,10 +206,18 @@ func (proof Proof) verifyLeafHashes(nth *Hasher, verifyCompleteness bool, nID na
 	return bytes.Equal(tree.Root(), root)
 }
 
-func (proof Proof) VerifyInclusion(h hash.Hash, nid namespace.ID, data []byte, root []byte) bool {
+func (proof Proof) VerifyInclusion(h hash.Hash, nid namespace.ID, data [][]byte, root []byte) bool {
 	nth := NewNmtHasher(h, nid.Size(), proof.isMaxNamespaceIDIgnored)
-	leafData := append(nid, data...)
-	return proof.verifyLeafHashes(nth, false, nid, [][]byte{nth.HashLeaf(leafData)}, root)
+	hashes := make([][]byte, len(data))
+	for i, d := range data {
+		leafData := append(append(
+			make([]byte, 0, len(d)+len(nid)),
+			nid...),
+			d...)
+		hashes[i] = nth.HashLeaf(leafData)
+	}
+
+	return proof.verifyLeafHashes(nth, false, nid, hashes, root)
 }
 
 // nextSubtreeSize returns the size of the subtree adjacent to start that does

--- a/proof.go
+++ b/proof.go
@@ -206,10 +206,14 @@ func (proof Proof) verifyLeafHashes(nth *Hasher, verifyCompleteness bool, nID na
 	return bytes.Equal(tree.Root(), root)
 }
 
-func (proof Proof) VerifyInclusion(h hash.Hash, nid namespace.ID, data [][]byte, root []byte) bool {
+// VerifyInclusion checks that the inclusion proof is valid by using leaf data
+// and the provided proof to regenerate and compare the root. Note that the leaf
+// data should not contain the prefixed namespace, unlike the tree.Push method,
+// which takes prefixed data
+func (proof Proof) VerifyInclusion(h hash.Hash, nid namespace.ID, leaves [][]byte, root []byte) bool {
 	nth := NewNmtHasher(h, nid.Size(), proof.isMaxNamespaceIDIgnored)
-	hashes := make([][]byte, len(data))
-	for i, d := range data {
+	hashes := make([][]byte, len(leaves))
+	for i, d := range leaves {
 		leafData := append(append(make([]byte, 0, len(d)+len(nid)), nid...), d...)
 		hashes[i] = nth.HashLeaf(leafData)
 	}

--- a/proof_test.go
+++ b/proof_test.go
@@ -153,8 +153,5 @@ func TestProof_MultipleLeaves(t *testing.T) {
 }
 
 func safeAppend(id, data []byte) []byte {
-	return append(append(
-		make([]byte, 0, len(id)+len(data)),
-		id...),
-		data...)
+	return append(append(make([]byte, 0, len(id)+len(data)), id...), data...)
 }


### PR DESCRIPTION
building on #57, we also need to be able to verify inclusion proofs for arbitrary ranges of leaves. 

Note: this PR is API breaking and will require another version bump