### PR TITLE
Remove dependency on nebulous in verification

### DIFF
--- a/hasher.go
+++ b/hasher.go
@@ -93,6 +93,7 @@ func (n *Hasher) EmptyRoot() []byte {
 // size of the underlying namespace.ID.
 //
 // Note that for leaves minNs = maxNs = ns(leaf) = leaf[:NamespaceLen].
+//
 //nolint:errcheck
 func (n *Hasher) HashLeaf(leaf []byte) []byte {
 	h := n.Hash

--- a/hasher.go
+++ b/hasher.go
@@ -92,7 +92,7 @@ func (n *Hasher) EmptyRoot() []byte {
 // Hence, the input length has to be greater or equal to the
 // size of the underlying namespace.ID.
 //
-//Note that for leaves minNs = maxNs = ns(leaf) = leaf[:NamespaceLen].
+// Note that for leaves minNs = maxNs = ns(leaf) = leaf[:NamespaceLen].
 //nolint:errcheck
 func (n *Hasher) HashLeaf(leaf []byte) []byte {
 	h := n.Hash

--- a/proof.go
+++ b/proof.go
@@ -197,11 +197,12 @@ func (proof Proof) verifyLeafHashes(nth *Hasher, verifyCompleteness bool, nID na
 		return hash
 	}
 
-	i := 1
-	for i < proof.end {
-		i *= 2
+	leavesSubtreeEstimate := getSplitPoint(proof.end) * 2
+	if leavesSubtreeEstimate < 1 {
+		leavesSubtreeEstimate = 1
 	}
-	rootHash := computeRoot(0, i)
+
+	rootHash := computeRoot(0, leavesSubtreeEstimate)
 	for i := 0; i < len(proof.nodes); i++ {
 		rootHash = nth.HashNode(rootHash, proof.nodes[i])
 	}

--- a/proof.go
+++ b/proof.go
@@ -202,9 +202,8 @@ func (proof Proof) verifyLeafHashes(nth *Hasher, verifyCompleteness bool, nID na
 		i *= 2
 	}
 	rootHash := computeRoot(0, i)
-	for len(proof.nodes) > 0 {
-		rootHash = nth.HashNode(rootHash, proof.nodes[0])
-		proof.nodes = proof.nodes[1:]
+	for i := 0; i < len(proof.nodes); i++ {
+		rootHash = nth.HashNode(rootHash, proof.nodes[i])
 	}
 
 	return bytes.Equal(rootHash, root)

--- a/proof.go
+++ b/proof.go
@@ -205,11 +205,12 @@ func (proof Proof) verifyLeafHashes(nth *Hasher, verifyCompleteness bool, nID na
 		return hash
 	}
 
-	leavesSubtreeEstimate := getSplitPoint(proof.end) * 2
-	if leavesSubtreeEstimate < 1 {
-		leavesSubtreeEstimate = 1
+	// estimate the leaf size of the subtree containing the proof range
+	proofRangeSubtreeEstimate := getSplitPoint(proof.end) * 2
+	if proofRangeSubtreeEstimate < 1 {
+		proofRangeSubtreeEstimate = 1
 	}
-	rootHash := computeRoot(0, leavesSubtreeEstimate)
+	rootHash := computeRoot(0, proofRangeSubtreeEstimate)
 	for i := 0; i < len(proof.nodes); i++ {
 		rootHash = nth.HashNode(rootHash, proof.nodes[i])
 	}

--- a/proof.go
+++ b/proof.go
@@ -211,9 +211,6 @@ func (proof Proof) verifyLeafHashes(nth *Hasher, verifyCompleteness bool, nID na
 		if right == nil {
 			return left
 		}
-		if left == nil {
-			return right
-		}
 		hash := nth.HashNode(left, right)
 		return hash
 	}

--- a/proof_test.go
+++ b/proof_test.go
@@ -74,9 +74,23 @@ func TestProof_VerifyNamespace_False(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// make copy of nodes for mutation check
+			duplicateNodes := make([][]byte, len(tt.proof.nodes))
+			for i := range tt.proof.nodes {
+				duplicateNodes[i] = make([]byte, len(tt.proof.nodes[i]))
+				copy(duplicateNodes[i], tt.proof.nodes[i])
+			}
+
 			got := tt.proof.VerifyNamespace(sha256.New(), tt.args.nID, tt.args.data, tt.args.root)
 			if got != tt.want {
 				t.Errorf("VerifyNamespace() got = %v, want %v", got, tt.want)
+			}
+
+			// check if proof was mutated during verification
+			for i := range tt.proof.nodes {
+				if !bytes.Equal(duplicateNodes[i], tt.proof.nodes[i]) {
+					t.Errorf("VerifyNameSpace() proof got mutated during verification")
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Use the same recursive approach as in `nmt.Root()` to verify leaf hashes
Removes the dependency on `Celestiaorg/merkletree` in proof verification

- [x] Implementation
- [x] Passing full testing

Fixes half of the issue mentioned in #15 