### PR TITLE
nmt: sanity check addition results to avoid overflows

### DIFF
--- a/subrootpaths_test.go
+++ b/subrootpaths_test.go
@@ -133,10 +133,13 @@ func TestPathGeneration(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		paths, err := GetSubrootPaths(tc.input.squareSize, tc.input.startNode, tc.input.length)
-		if !reflect.DeepEqual(pathResult(paths), tc.want) {
-			t.Fatalf(`GetSubrootPaths(%v) = %v, %v, want %v - rationale: %v`, tc.input, paths, err, tc.want, tc.desc)
-		}
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			paths, err := GetSubrootPaths(tc.input.squareSize, tc.input.startNode, tc.input.length)
+			if !reflect.DeepEqual(pathResult(paths), tc.want) {
+				t.Fatalf(`GetSubrootPaths(%v) = %v, %v, want %v - rationale: %v`, tc.input, paths, err, tc.want, tc.desc)
+			}
+		})
 	}
 
 }


### PR DESCRIPTION
This change cautiously checks addition results to prevent integer overflows. Also checks errors from left and right GetSubrootPaths generation to avoid any future runtime panics. While here, also slightly tweaked table tests for TestPathGeneration to use subtests and report which case failed exactly.