### PR TITLE
docs: improve namespace doc

### DIFF
--- a/namespace/doc.go
+++ b/namespace/doc.go
@@ -1,4 +1,4 @@
-// Package namespace contains the core namespaced data types:
-// * PrefixedData represents the leaf data that gets pushed to the NMT (data prefixed with a namespace.ID)
-// * IntervalDigest is the result of a namespaced hashing operation (minNs, maxNs, rawRoot).
+// Package namespace contains the core namespaced data types. [PrefixedData]
+// represents the leaf data that gets pushed to the NMT (data prefixed with an
+// [ID]).
 package namespace


### PR DESCRIPTION
- Link to types
- Remove IntervalDigest because it doesn't exist in this package

## Screenshot
<img width="832" alt="Screen Shot 2022-10-25 at 10 40 22 AM" src="https://user-images.githubusercontent.com/3699047/197726805-e088088e-75b9-4358-a3f9-3d585e9167b3.png">
