### PR TITLE
chore: fixes the HashLeaf description

### DIFF
--- a/hasher.go
+++ b/hasher.go
@@ -144,8 +144,8 @@ func (n *Hasher) EmptyRoot() []byte {
 }
 
 // HashLeaf hashes leaves to:
-// ns(rawData) || ns(rawData) || hash(leafPrefix || rawData), where raw data is the leaf's
-// data minus the namespaceID (namely leaf[NamespaceLen:]).
+// ns(leaf) || ns(leaf) || hash(leafPrefix || leaf), where ns(leaf) is the namespaceID
+// inside the leaf's data namely leaf[:n.NamespaceLen]).
 // Hence, the input length has to be greater or equal to the
 // size of the underlying namespace.ID.
 //
@@ -159,7 +159,7 @@ func (n *Hasher) HashLeaf(leaf []byte) []byte {
 	nID := leaf[:n.NamespaceLen]
 	resLen := int(2*n.NamespaceLen) + n.baseHasher.Size()
 	res := append(append(make([]byte, 0, resLen), nID...), nID...)
-	// h(0x00, d.namespaceID, d.rawData)
+	// h(0x00, leaf)
 	data := append(append(make([]byte, 0, len(leaf)+1), LeafPrefix), leaf...)
 	h.Write(data)
 	return h.Sum(res)


### PR DESCRIPTION
## Overview

While reviewing the nmt codebase (as part of this [EPIC](https://github.com/celestiaorg/celestia-app/issues/1296)) I realized the description of the `HashLeaf` function does not match its implementation (w.r.t. referred variable names) which causes confusion when comprehending the code.  This PR aims to correct and revise that description. 

Also, the illustration of an nmt provided in the [Readme file](https://github.com/celestiaorg/nmt/blob/master/README.md) seems not aligned with the leaf hash calculation, where in the `node_0.0` the `d_0.0=H(data_0)` while it should be `d_0.0=H(0x00, nid_0, data_0)`. I was not able to edit the image as its source code is not available. 
