### PR TITLE
fix: use `baseHasher.Size` for `sha256Len` instead of `n.Size`

### DIFF
--- a/hasher.go
+++ b/hasher.go
@@ -117,7 +117,7 @@ func (n *Hasher) Sum([]byte) []byte {
 		return n.HashLeaf(n.data)
 	case NodePrefix:
 		flagLen := int(n.NamespaceLen) * 2
-		sha256Len := n.Size()
+		sha256Len := n.baseHasher.Size()
 		return n.HashNode(n.data[:flagLen+sha256Len], n.data[flagLen+sha256Len:])
 	default:
 		panic("nmt node type wasn't set")


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
This PR fixes the bug included in the last release, that resulted (silently) in producing a different hash than the original hasher.

Related: 
https://github.com/celestiaorg/celestia-core/pull/954
https://github.com/celestiaorg/celestia-node/pull/1651
<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
