### PR TITLE
chore!: remove unused API functions Sha256Namespace8FlaggedLeaf and Sha256Namespace8FlaggedInner from the hasher

### DIFF
--- a/hasher_test.go
+++ b/hasher_test.go
@@ -19,6 +19,10 @@ const (
 	innerSize = 2 * hashSize
 )
 
+// defaultHasher uses sha256 as a base-hasher, 8 bytes for the namespace IDs and
+// ignores the maximum possible namespace.
+var defaultHasher = NewNmtHasher(sha256.New(), DefaultNamespaceIDLen, true)
+
 func Test_namespacedTreeHasher_HashLeaf(t *testing.T) {
 	zeroNID := []byte{0}
 	oneNID := []byte{1}

--- a/hasher_test.go
+++ b/hasher_test.go
@@ -114,57 +114,6 @@ func Test_namespacedTreeHasher_HashNode(t *testing.T) {
 	}
 }
 
-func TestSha256Namespace8FlaggedLeaf(t *testing.T) {
-	tests := []struct {
-		name      string
-		data      []byte
-		wantPanic bool
-		wantLen   int
-	}{
-		{"input too short: panic", []byte("smaller"), true, 0},
-		{"input 8 byte: Ok", []byte("8bytesss"), false, 48},
-		{"input greater 8 byte: Ok", []byte("8bytesssSomeNotSoRandData"), false, 48},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if tt.wantPanic {
-				shouldPanic(t, func() {
-					Sha256Namespace8FlaggedLeaf(tt.data)
-				})
-			} else if got := Sha256Namespace8FlaggedLeaf(tt.data); len(got) != tt.wantLen {
-				t.Errorf("len(Sha256Namespace8FlaggedLeaf()) = %v, want %v", got, tt.wantLen)
-			}
-		})
-	}
-}
-
-func TestSha256Namespace8FlaggedInner(t *testing.T) {
-	nilHash := sha256.Sum256(nil)
-	nid1 := []byte("nid01234")
-	nid2 := []byte("nid12345")
-	tests := []struct {
-		name      string
-		data      []byte
-		wantPanic bool
-		wantLen   int
-	}{
-		{"input smaller 48: panic", []byte("smaller48"), true, 0},
-		{"input still too small: panic", append(append(nid1, nid2...), []byte("data")...), true, 0},
-		{"valid input: ok", append(append(append(nid1, nilHash[:]...), nid2...), nilHash[:]...), false, 48},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if tt.wantPanic {
-				shouldPanic(t, func() {
-					Sha256Namespace8FlaggedInner(tt.data)
-				})
-			} else if got := Sha256Namespace8FlaggedInner(tt.data); len(got) != tt.wantLen {
-				t.Errorf("len(Sha256Namespace8FlaggedLeaf()) = %v, want %v", got, tt.wantLen)
-			}
-		})
-	}
-}
-
 func sum(hash crypto.Hash, data ...[]byte) []byte {
 	h := hash.New()
 	for _, d := range data {


### PR DESCRIPTION
## Overview
The following two functions `Sha256Namespace8FlaggedLeaf` and `Sha256Namespace8FlaggedInner` are part of the public APIs, however, they are no longer needed as mentioned by @liamsi in https://github.com/celestiaorg/nmt/issues/87#issuecomment-1355165925. I also verified it against the main branch and the latest release (v0.7.0-rc4@8b9937f) of celestia-node codebase and no usage was found. Likewise, no usage was available in the clestia-core repo.

**Summary of changes:**
- This PR deletes these `Sha256Namespace8FlaggedLeaf` and `Sha256Namespace8FlaggedInner` functions and the relevant tests.
- After performing this update, it was found that there was no longer any use case for the `defaultHasher` in the main hasher file, and it is now only being used in the test file. As a result, it has been moved accordingly.

## Checklist
- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates (based on the responses from code-owners, it is safe to say there is no mention to these functions in any doc)
- [x] Linked issues closed with keywords

This change is inline with https://github.com/celestiaorg/celestia-app/issues/1296 and https://github.com/celestiaorg/nmt/issues/95.
