### PR TITLE
chore: fixes the description of the index of leafHash in the absence proof

### DIFF
--- a/nmt.go
+++ b/nmt.go
@@ -188,9 +188,8 @@ func (n *NamespacedMerkleTree) ProveRange(start, end int) (Proof, error) {
 // namespace i.e., n.minNID<= n.ID <=n.maxNID and the tree does not have any
 // entries with the given Namespace ID nID, this will be proven by returning the
 // inclusion/range Proof of the (namespaced or rather flagged) hash of the leaf
-// of the tree 1) with the largest namespace ID that is smaller than nID and 2)
-// the namespace ID of the leaf to the left of it is smaller than the nid 3) the
-// namespace ID of the leaf to the right of it is larger than nid. The nodes
+// of the tree 1) with the smallest namespace ID that is larger than nID and 2)
+// the namespace ID of the leaf to the left of it is smaller than the nid. The nodes
 // field of the returned Proof structure is populated with the Merkle inclusion
 // proof. the leafHash field of the returned Proof will contain the namespaced
 // hash of such leaf. The start and end fields of the Proof are set to the

--- a/proof.go
+++ b/proof.go
@@ -26,10 +26,9 @@ type Proof struct {
 	// leafHash are nil if the namespace is present in the NMT. In case the
 	// namespace to be proved is in the min/max range of the tree but absent,
 	// this will contain the leaf hash necessary to verify the proof of absence.
-	// leafHash contains a tree leaf that 1) its namespace ID is the largest
-	// namespace ID less than nid and 2) the namespace ID of the leaf to the
-	// left of it is smaller than the nid 3) the namespace ID of the  leaf to
-	// the right of it is larger than nid.
+	// leafHash contains a tree leaf that 1) its namespace ID is the smallest
+	// namespace ID larger than nid and 2) the namespace ID of the leaf to the
+	// left of it is smaller than the nid.
 	leafHash []byte
 	// isMaxNamespaceIDIgnored is set to true if the tree from which this Proof
 	// was generated from is initialized with Options.IgnoreMaxNamespace ==


### PR DESCRIPTION
## Overview

This PR intends to bring the description of the `leafHash` field in the `Proof `data structure in line with the specification. Additionally, among the three criteria enumerated for the `leafHash` the third criterion  is redundant since it is already covered by the first two. Although this has already been addressed in the specification, the code description needs to be updated, and this PR accomplishes that (this comment was originally raised in https://github.com/celestiaorg/nmt/issues/110#issuecomment-1448413024).

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
