### PR TITLE
feat:  check the namespace ID range of the leafHash in an absence proof to ensure soundness

### DIFF
--- a/proof.go
+++ b/proof.go
@@ -143,6 +143,13 @@ func (proof Proof) VerifyNamespace(h hash.Hash, nID namespace.ID, data [][]byte,
 	nIDLen := nID.Size()
 	if proof.IsOfAbsence() {
 		gotLeafHashes = append(gotLeafHashes, proof.leafHash)
+		// conduct some sanity checks:
+		leafMinNID := namespace.ID(proof.leafHash[:nIDLen])
+		if !nID.Less(leafMinNID) {
+			// leafHash.minNID  must be greater than nID
+			return false
+		}
+
 	} else {
 		// collect leaf hashes from provided data and do some sanity checks:
 		hashLeafFunc := nth.HashLeaf

--- a/proof_test.go
+++ b/proof_test.go
@@ -83,6 +83,14 @@ func TestProof_VerifyNamespace_False(t *testing.T) {
 	}
 	pushedZeroNs := n.Get([]byte{0, 0, 0})
 	pushedLastNs := n.Get([]byte{0, 0, 8})
+
+	// an invalid absence proof for an existing namespace ID (2) in the constructed tree
+	leafIndex := 3
+	inclusionProofOfLeafIndex := rangeProof(t, n, leafIndex, leafIndex+1)
+	n.computeLeafHashesIfNecessary()
+	leafHash := n.leafHashes[leafIndex] // the only data item with namespace ID = 2 in the constructed tree is at index 3
+	invalidAbsenceProof := NewAbsenceProof(leafIndex, leafIndex+1, inclusionProofOfLeafIndex, leafHash, false)
+
 	tests := []struct {
 		name  string
 		proof Proof
@@ -132,6 +140,11 @@ func TestProof_VerifyNamespace_False(t *testing.T) {
 		{
 			"remove all leaves, errors", validProof,
 			args{[]byte{0, 0, 0}, pushedZeroNs[:len(pushedZeroNs)-2], n.Root()},
+			false,
+		},
+		{
+			"invalid absence proof of an existing nid", invalidAbsenceProof,
+			args{[]byte{0, 0, 2}, [][]byte{}, n.Root()},
 			false,
 		},
 	}

--- a/spec/nmt.md
+++ b/spec/nmt.md
@@ -126,9 +126,10 @@ As an example, the namespace proof for `nID = 0` for the NMT of Figure 1 (which 
 
 ### Verification of NMT Absence Proof
 
-An NMT absence proof is deemed valid if 
-1) The verification of Merkle inclusion proof of the returned leaf is valid.  
-2) It satisfies the proof completeness as explained in the [Verification of NMT Inclusion Proof](#verification-of-nmt-inclusion-proof).
+An NMT absence proof is deemed valid if it meets the following:
+1) The minimum namespace ID of the leaf in the proof is greater than the queried `nID`. 
+2) The verification of Merkle inclusion proof of the returned leaf is valid.  
+3) It satisfies the proof completeness as explained in the [Verification of NMT Inclusion Proof](#verification-of-nmt-inclusion-proof).
 Note that hash of the leaf does not have to be verified against the underlying message.
 
 ### Verification of Empty NMT proof


### PR DESCRIPTION
## Overview

Addresses the issue set out in #115.

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
