### PR TITLE
chore: upgrade to Go 1.19

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.18
+          go-version: ^1.19
         id: go
 
       - name: Check out code into the Go module directory

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Namespaced Merkle Tree (NMT)
 
-![Go version](https://img.shields.io/badge/go-1.18-blue.svg)
+![Go version](https://img.shields.io/badge/go-1.19-blue.svg)
 [![API Reference](https://camo.githubusercontent.com/915b7be44ada53c290eb157634330494ebe3e30a/68747470733a2f2f676f646f632e6f72672f6769746875622e636f6d2f676f6c616e672f6764646f3f7374617475732e737667)](https://pkg.go.dev/github.com/celestiaorg/nmt)
 ![golangci-lint](https://github.com/celestiaorg/nmt/workflows/golangci-lint/badge.svg?branch=master)
 ![Go](https://github.com/celestiaorg/nmt/workflows/Go/badge.svg)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/celestiaorg/nmt
 
-go 1.18
+go 1.19
 
 require (
 	github.com/celestiaorg/merkletree v0.0.0-20210714075610-a84dc3ddbbe4


### PR DESCRIPTION
Go 1.18 is no longer supported (see [endoflife](https://endoflife.date/go)) so this PR upgrades to Go 1.19. We could also upgrade directly to Go 1.20 but I opted for 1.19 because most other celestiaorg repos are on Go 1.19.