### PR TITLE
feat!:  updates the HashNode and HashLeaf methods to return error instead of panic and refactors the code

### DIFF
--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -2,10 +2,11 @@ package nmt_test
 
 import (
 	"crypto/sha256"
-	"github.com/stretchr/testify/require"
 	"reflect"
 	"sort"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/celestiaorg/nmt"
 	"github.com/celestiaorg/nmt/namespace"

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -2,6 +2,7 @@ package nmt_test
 
 import (
 	"crypto/sha256"
+	"github.com/stretchr/testify/require"
 	"reflect"
 	"sort"
 	"testing"
@@ -44,7 +45,8 @@ func TestFuzzProveVerifyNameSpace(t *testing.T) {
 			}
 		}
 
-		treeRoot := tree.Root()
+		treeRoot, err := tree.Root()
+		require.NoError(t, err)
 		nonEmptyNsCount := 0
 		leafIdx := 0
 		for _, ns := range sortedKeys {

--- a/hasher.go
+++ b/hasher.go
@@ -82,17 +82,15 @@ func (n *Hasher) Write(data []byte) (int, error) {
 		rightChild := data[n.Size():]
 		if err := n.ValidateNodes(leftChild, rightChild); err != nil {
 			return 0, err
-		} else {
-			n.tp = NodePrefix
 		}
+		n.tp = NodePrefix
 	// leaf nodes contain the namespace length and a share
 	default:
 		// validate leaf format
 		if err := n.ValidateLeaf(data); err != nil {
 			return 0, err
-		} else {
-			n.tp = LeafPrefix
 		}
+		n.tp = LeafPrefix
 	}
 
 	n.data = data

--- a/hasher.go
+++ b/hasher.go
@@ -77,6 +77,7 @@ func (n *Hasher) Write(data []byte) (int, error) {
 	switch ln {
 	// inner nodes are made up of the nmt hashes of the left and right children
 	case n.Size() * 2:
+		// check the format of the data
 		leftChild := data[:n.Size()]
 		rightChild := data[n.Size():]
 		if err := n.ValidateNodes(leftChild, rightChild); err != nil {

--- a/hasher.go
+++ b/hasher.go
@@ -67,7 +67,7 @@ func (n *Hasher) Size() int {
 // Requires data of fixed size to match leaf or inner NMT nodes. Only a single
 // write is allowed.
 // It panics if more than one single write is attempted.
-// If the data does not match an NMT non-leaf node or leaf node, an error will be returned.
+// If the data does not match the format of an NMT non-leaf node or leaf node, an error will be returned.
 func (n *Hasher) Write(data []byte) (int, error) {
 	if n.data != nil {
 		panic("only a single Write is allowed")
@@ -213,7 +213,7 @@ func (n *Hasher) validateSiblingsNamespaceOrder(left, right []byte) (err error) 
 	return nil
 }
 
-// ValidateNodes is helper function  to verify the
+// ValidateNodes is a helper function  to verify the
 // validity of the inputs of HashNode. It verifies whether left
 // and right comply by the namespace hash format, and are correctly ordered
 // according to their namespace IDs.

--- a/hasher.go
+++ b/hasher.go
@@ -140,7 +140,7 @@ func (n *Hasher) EmptyRoot() []byte {
 	return digest
 }
 
-// ValidateLeaf checks whether data is namespace prefixed.
+// ValidateLeaf verifies if data is namespaced and returns an error if not.
 func (n *Hasher) ValidateLeaf(data []byte) (err error) {
 	nidSize := int(n.NamespaceSize())
 	lenData := len(data)

--- a/hasher.go
+++ b/hasher.go
@@ -86,7 +86,7 @@ func (n *Hasher) Write(data []byte) (int, error) {
 		n.tp = NodePrefix
 	// leaf nodes contain the namespace length and a share
 	default:
-		// validate leaf format
+		// validate the format of the leaf
 		if err := n.ValidateLeaf(data); err != nil {
 			return 0, err
 		}
@@ -224,10 +224,7 @@ func (n *Hasher) ValidateNodes(left, right []byte) error {
 	if err := n.ValidateNodeFormat(right); err != nil {
 		return err
 	}
-	if err := n.validateSiblingsNamespaceOrder(left, right); err != nil {
-		return err
-	}
-	return nil
+	return n.validateSiblingsNamespaceOrder(left, right)
 }
 
 // HashNode calculates a namespaced hash of a node using the supplied left and

--- a/hasher.go
+++ b/hasher.go
@@ -182,7 +182,7 @@ func (n *Hasher) HashLeaf(ndata []byte) ([]byte, error) {
 }
 
 // ValidateNodeFormat checks whether the supplied node conforms to the
-// namespaced hash format and returns an error if it does not.
+// namespaced hash format and returns an error if it does not. Specifically, it returns ErrInvalidNodeLen if the length of the node is less than the 2*namespace length which indicates it does not match the namespaced hash format.
 func (n *Hasher) ValidateNodeFormat(node []byte) (err error) {
 	totalNamespaceLen := 2 * n.NamespaceLen
 	nodeLen := len(node)
@@ -195,9 +195,9 @@ func (n *Hasher) ValidateNodeFormat(node []byte) (err error) {
 // validateSiblingsNamespaceOrder checks whether left and right as two sibling
 // nodes in an NMT have correct namespace IDs relative to each other, more
 // specifically, the maximum namespace ID of the left sibling should not exceed
-// the minimum namespace ID of the right sibling. Note that the function assumes
+// the minimum namespace ID of the right sibling. It returns ErrUnorderedSiblings error if the check fails. Note that the function assumes
 // that the left and right nodes are in correct format, i.e., they are
-// namespaced hash values.
+// namespaced hash values. Otherwise, it panics.
 func (n *Hasher) validateSiblingsNamespaceOrder(left, right []byte) (err error) {
 	// each NMT node has two namespace IDs for the min and max
 	totalNamespaceLen := 2 * n.NamespaceLen

--- a/hasher.go
+++ b/hasher.go
@@ -145,7 +145,7 @@ func (n *Hasher) ValidateLeaf(data []byte) (err error) {
 	nidSize := int(n.NamespaceSize())
 	lenData := len(data)
 	if lenData < nidSize {
-		return fmt.Errorf("%w: got: %v, want >= %v", ErrMismatchedNamespaceSize, lenData, nidSize)
+		return fmt.Errorf("%w: got: %v, want >= %v", ErrInvalidNodeLen, lenData, nidSize)
 	}
 	return nil
 }
@@ -208,22 +208,6 @@ func (n *Hasher) validateSiblingsNamespaceOrder(left, right []byte) (err error) 
 	// check the namespace range of the left and right children
 	if rightMinNs.Less(leftMaxNs) {
 		return fmt.Errorf("%w: the maximum namespace of the left child %x is greater than the min namespace of the right child %x", ErrUnorderedSiblings, leftMaxNs, rightMinNs)
-	}
-	return nil
-}
-
-// validateNodes  is a helper function that verifies the inputs of HashNode.
-// It verifies whether the two siblings left and right comply by the namespace hash format,
-// and are correctly ordered according to their namespace IDs.
-func (n *Hasher) validateNodes(left, right []byte) error {
-	if err := n.ValidateNodeFormat(left); err != nil {
-		return err
-	}
-	if err := n.ValidateNodeFormat(right); err != nil {
-		return err
-	}
-	if err := n.validateSiblingsNamespaceOrder(left, right); err != nil {
-		return err
 	}
 	return nil
 }

--- a/hasher.go
+++ b/hasher.go
@@ -227,7 +227,7 @@ func (n *Hasher) validateSiblingsNamespaceOrder(left, right []byte) (err error) 
 // IDs available in the range of its left and right children that are not
 // equal to the maximum possible namespace ID value. If all the namespace IDs are equal
 // to the maximum possible value, then the maximum possible value is used.
-func (n *Hasher) HashNode(left, right []byte) []byte {
+func (n *Hasher) HashNode(left, right []byte) ([]byte, error) {
 	h := n.baseHasher
 	h.Reset()
 

--- a/hasher.go
+++ b/hasher.go
@@ -80,7 +80,8 @@ func (n *Hasher) Write(data []byte) (int, error) {
 		// check the format of the data
 		leftChild := data[:n.Size()]
 		rightChild := data[n.Size():]
-		if err := n.ValidateNodes(leftChild, rightChild); err != nil {
+		err := n.ValidateNodes(leftChild, rightChild)
+		if err != nil {
 			return 0, err
 		}
 		n.tp = NodePrefix

--- a/hasher.go
+++ b/hasher.go
@@ -80,18 +80,19 @@ func (n *Hasher) Write(data []byte) (int, error) {
 		// check the format of the data
 		leftChild := data[:n.Size()]
 		rightChild := data[n.Size():]
-		err := n.ValidateNodes(leftChild, rightChild)
-		if err != nil {
+		if err := n.ValidateNodes(leftChild, rightChild); err != nil {
 			return 0, err
+		} else {
+			n.tp = NodePrefix
 		}
-		n.tp = NodePrefix
 	// leaf nodes contain the namespace length and a share
 	default:
 		// validate leaf format
 		if err := n.ValidateLeaf(data); err != nil {
 			return 0, err
+		} else {
+			n.tp = LeafPrefix
 		}
-		n.tp = LeafPrefix
 	}
 
 	n.data = data

--- a/hasher.go
+++ b/hasher.go
@@ -115,7 +115,7 @@ func (n *Hasher) Sum([]byte) []byte {
 		rightChild := n.data[flagLen+sha256Len:]
 		res, err := n.HashNode(leftChild, rightChild)
 		if err != nil {
-			panic(err)
+			panic(err) // this should never happen since the data is already validated in the Write method
 		}
 		return res
 	default:

--- a/hasher_test.go
+++ b/hasher_test.go
@@ -524,7 +524,6 @@ func Test_NamespaceHasherSum_Err(t *testing.T) {
 			})
 		}
 	}
-
 }
 
 // Test_ValidateNodes checks that the ValidateNodes method only emits error on invalid inputs. It also checks whether the returned error types are correct.

--- a/hasher_test.go
+++ b/hasher_test.go
@@ -318,7 +318,7 @@ func TestValidateNodeFormat(t *testing.T) {
 	}
 }
 
-func TestIsNamespacedData(t *testing.T) {
+func TestValidateLeaf(t *testing.T) {
 	tests := []struct {
 		name    string
 		data    []byte
@@ -342,6 +342,38 @@ func TestIsNamespacedData(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			n := NewNmtHasher(sha256.New(), tt.nIDLen, false)
 			assert.Equal(t, tt.wantErr, n.ValidateLeaf(tt.data) != nil)
+		})
+	}
+}
+
+// TestValidateLeafWithHash tests the HashLeaf does not error out for the leaves that are validated by ValidateLeaf.
+func TestValidateLeafWithHash(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    []byte
+		nIDLen  namespace.IDSize
+		wantErr bool
+	}{
+		{
+			"valid namespaced data",
+			[]byte{0, 0},
+			2,
+			false,
+		},
+		{
+			"non-namespaced data",
+			[]byte{1},
+			2,
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := NewNmtHasher(sha256.New(), tt.nIDLen, false)
+			validationRes := n.ValidateLeaf(tt.data)
+			assert.Equal(t, tt.wantErr, validationRes != nil)
+			_, err := n.HashLeaf(tt.data)
+			assert.Equal(t, validationRes != nil, err != nil)
 		})
 	}
 }

--- a/hasher_test.go
+++ b/hasher_test.go
@@ -349,30 +349,30 @@ func TestIsNamespacedData(t *testing.T) {
 func TestHashLeafWithIsNamespacedData(t *testing.T) {
 	tests := []struct {
 		name    string
-		data    []byte
+		leaf    []byte
 		nIDLen  namespace.IDSize
 		wantErr bool
 		errType error
 	}{
 		{
-			"valid namespaced data",
+			"valid namespaced leaf",
 			[]byte{0, 0},
 			2,
 			false,
 			nil,
 		},
 		{
-			"non-namespaced data",
+			"non-namespaced leaf",
 			[]byte{1},
 			2,
 			true,
-			ErrInvalidNodeLen,
+			ErrInvalidLeafLen,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			n := NewNmtHasher(sha256.New(), tt.nIDLen, false)
-			_, err := n.HashLeaf(tt.data)
+			_, err := n.HashLeaf(tt.leaf)
 			assert.Equal(t, tt.wantErr, err != nil)
 			if tt.wantErr {
 				assert.True(t, errors.Is(err, tt.errType))
@@ -381,8 +381,7 @@ func TestHashLeafWithIsNamespacedData(t *testing.T) {
 	}
 }
 
-// TestHashNodeWithValidateNodes checks whether the HashNode errors out when invalid inputs are given.
-// It also checks that the HashNode does not error out for valid inputs.
+// TestHashNodeWithValidateNodes checks that the HashNode emits error only on invalid inputs and whether the returned error types are correct.
 func TestHashNode_ErrorsCheck(t *testing.T) {
 	type children struct {
 		l []byte // namespace hash of the left child with the format of MinNs||MaxNs||h

--- a/hasher_test.go
+++ b/hasher_test.go
@@ -438,8 +438,8 @@ func TestHashNode_ErrorsCheck(t *testing.T) {
 	}
 }
 
-// Test_Write_Err checks that the Write method emits error on invalid inputs.
-func Test_Write_Err(t *testing.T) {
+// TestWrite_Err checks that the Write method emits error on invalid inputs.
+func TestWrite_Err(t *testing.T) {
 	hash := sha256.New()
 	hash.Write([]byte("random data"))
 	randData := hash.Sum(nil)
@@ -477,8 +477,8 @@ func Test_Write_Err(t *testing.T) {
 	}
 }
 
-// Test_NamespaceHasherSum_Err checks that the Sum method emits error on invalid inputs and when the hasher is not in the correct state.
-func Test_NamespaceHasherSum_Err(t *testing.T) {
+// TestSum_Err checks that the Sum method emits error on invalid inputs and when the hasher is not in the correct state.
+func TestSum_Err(t *testing.T) {
 	hash := sha256.New()
 	hash.Write([]byte("random data"))
 	randData := hash.Sum(nil)
@@ -526,8 +526,8 @@ func Test_NamespaceHasherSum_Err(t *testing.T) {
 	}
 }
 
-// Test_ValidateNodes checks that the ValidateNodes method only emits error on invalid inputs. It also checks whether the returned error types are correct.
-func Test_ValidateNodes(t *testing.T) {
+// TestValidateNodes checks that the ValidateNodes method only emits error on invalid inputs. It also checks whether the returned error types are correct.
+func TestValidateNodes(t *testing.T) {
 	tests := []struct {
 		name    string
 		nIDLen  namespace.IDSize

--- a/hasher_test.go
+++ b/hasher_test.go
@@ -381,7 +381,7 @@ func TestHashLeafWithIsNamespacedData(t *testing.T) {
 	}
 }
 
-// TestHashNodeWithValidateNodes checks that the HashNode emits error only on invalid inputs and whether the returned error types are correct.
+// TestHashNode_ErrorsCheck checks that the HashNode emits error only on invalid inputs. It also checks whether the returned error types are correct.
 func TestHashNode_ErrorsCheck(t *testing.T) {
 	type children struct {
 		l []byte // namespace hash of the left child with the format of MinNs||MaxNs||h

--- a/hasher_test.go
+++ b/hasher_test.go
@@ -437,3 +437,29 @@ func TestHashNode_ErrorsCheck(t *testing.T) {
 		})
 	}
 }
+
+// Test_Write_Err checks that the Write method emits error on invalid inputs.
+func Test_Write_Err(t *testing.T) {
+	hasher := NewNmtHasher(sha256.New(), 2, false)
+	tests := []struct {
+		name    string
+		data    []byte
+		wantErr bool
+		errType error
+	}{
+		{"invalid leaf",
+			[]byte{0},
+			true,
+			ErrInvalidLeafLen,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := hasher.Write(tt.data)
+			assert.Equal(t, tt.wantErr, err != nil)
+			if tt.wantErr {
+				assert.True(t, errors.Is(err, tt.errType))
+			}
+		})
+	}
+}

--- a/hasher_test.go
+++ b/hasher_test.go
@@ -438,8 +438,8 @@ func TestHashNode_ErrorsCheck(t *testing.T) {
 	}
 }
 
-// TestWrite_Err checks that the Write method emits error on invalid inputs.
-func TestWrite_Err(t *testing.T) {
+// Test_Write_Err checks that the Write method emits error on invalid inputs.
+func Test_Write_Err(t *testing.T) {
 	hash := sha256.New()
 	hash.Write([]byte("random data"))
 	randData := hash.Sum(nil)
@@ -477,8 +477,8 @@ func TestWrite_Err(t *testing.T) {
 	}
 }
 
-// TestNamespaceHasherSum_Err checks that the Sum method emits error on invalid inputs and when the hasher is not in the correct state.
-func TestNamespaceHasherSum_Err(t *testing.T) {
+// Test_NamespaceHasherSum_Err checks that the Sum method emits error on invalid inputs and when the hasher is not in the correct state.
+func Test_NamespaceHasherSum_Err(t *testing.T) {
 	hash := sha256.New()
 	hash.Write([]byte("random data"))
 	randData := hash.Sum(nil)
@@ -527,8 +527,8 @@ func TestNamespaceHasherSum_Err(t *testing.T) {
 
 }
 
-// TestValidateNodes checks that the ValidateNodes method only emits error on invalid inputs. It also checks whether the returned error types are correct.
-func TestValidateNodes(t *testing.T) {
+// Test_ValidateNodes checks that the ValidateNodes method only emits error on invalid inputs. It also checks whether the returned error types are correct.
+func Test_ValidateNodes(t *testing.T) {
 	tests := []struct {
 		name    string
 		nIDLen  namespace.IDSize

--- a/hasher_test.go
+++ b/hasher_test.go
@@ -447,7 +447,8 @@ func Test_Write_Err(t *testing.T) {
 		wantErr bool
 		errType error
 	}{
-		{"invalid leaf",
+		{
+			"invalid leaf",
 			[]byte{0},
 			true,
 			ErrInvalidLeafLen,

--- a/hasher_test.go
+++ b/hasher_test.go
@@ -491,7 +491,7 @@ func TestWrite_Err(t *testing.T) {
 			ErrInvalidLeafLen,
 		},
 		{
-			"invalid node: left.max > right.imn",
+			"invalid node: left.max > right.min",
 			NewNmtHasher(sha256.New(), 2, false),
 			append(append(append([]byte{0, 0, 2, 2}, randData...), []byte{1, 1, 3, 3}...), randData...),
 			true,

--- a/hasher_test.go
+++ b/hasher_test.go
@@ -235,7 +235,6 @@ func TestHashNode_ChildrenNamespaceRange(t *testing.T) {
 			if tt.wantErr {
 				assert.True(t, errors.Is(err, tt.errType))
 			}
-
 		})
 	}
 }

--- a/hasher_test.go
+++ b/hasher_test.go
@@ -211,7 +211,7 @@ func TestHashNode_ChildrenNamespaceRange(t *testing.T) {
 		{
 			"left.maxNs>right.minNs", 2,
 			children{[]byte{0, 0, 1, 1}, []byte{0, 0, 1, 1}},
-			true, // this test case should emit error since in an ordered NMT, left.maxNs cannot be greater than right.minNs
+			true, // this test case should emit an error since in an ordered NMT, left.maxNs cannot be greater than right.minNs
 			ErrUnorderedSiblings,
 		},
 		{

--- a/hasher_test.go
+++ b/hasher_test.go
@@ -516,11 +516,11 @@ func TestSum_Err(t *testing.T) {
 	randData := hash.Sum(nil)
 
 	tests := []struct {
-		name     string
-		hasher   *Hasher
-		data     []byte
-		nodeType byte
-		wantErr  bool
+		name         string
+		hasher       *Hasher
+		data         []byte
+		nodeType     byte
+		wantWriteErr bool
 	}{
 		{
 			"invalid leaf: not namespaced",
@@ -540,7 +540,7 @@ func TestSum_Err(t *testing.T) {
 	for _, tt := range tests {
 		// Write -> Sum should never panic
 		_, err := tt.hasher.Write(tt.data)
-		require.Equal(t, tt.wantErr, err != nil)
+		require.Equal(t, tt.wantWriteErr, err != nil)
 		if err == nil {
 			require.NotPanics(t, func() {
 				tt.hasher.Sum(nil)

--- a/hasher_test.go
+++ b/hasher_test.go
@@ -438,7 +438,7 @@ func TestHashNode_ErrorsCheck(t *testing.T) {
 	}
 }
 
-// Test_Write_Err checks that the Write method emits error on invalid inputs.
+// TestWrite_Err checks that the Write method emits error on invalid inputs.
 func TestWrite_Err(t *testing.T) {
 	hash := sha256.New()
 	hash.Write([]byte("random data"))

--- a/hasher_test.go
+++ b/hasher_test.go
@@ -465,6 +465,7 @@ func TestWrite_Err(t *testing.T) {
 	}
 }
 
+// TestValidateNodes checks that the ValidateNodes method only emits error on invalid inputs. It also checks whether the returned error types are correct.
 func TestValidateNodes(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/nmt.go
+++ b/nmt.go
@@ -163,7 +163,8 @@ func (n *NamespacedMerkleTree) Prove(index int) (Proof, error) {
 // generated using a modified version of the namespace hash with a custom
 // namespace ID range calculation. For more information on this, please refer to
 // the HashNode method in the Hasher.
-// If the supplied (start, end) range is invalid i.e., if start < 0 or end > len(n.leaves), then ProveRange returns an ErrInvalidRange error. Any errors rather than ErrInvalidRange are irrecoverable and indicate an illegal state of the tree (n).
+// If the supplied (start, end) range is invalid i.e., if start < 0 or end > len(n.leafHashes) or start >= end,
+// then ProveRange returns an ErrInvalidRange error. Any errors rather than ErrInvalidRange are irrecoverable and indicate an illegal state of the tree (n).
 func (n *NamespacedMerkleTree) ProveRange(start, end int) (Proof, error) {
 	isMaxNsIgnored := n.treeHasher.IsMaxNamespaceIDIgnored()
 	if err := n.computeLeafHashesIfNecessary(); err != nil {
@@ -579,7 +580,7 @@ func (n *NamespacedMerkleTree) updateMinMaxID(id namespace.ID) {
 
 // computes the leaf hashes if not already done in a previous call of
 // NamespacedMerkleTree.Root()
-// computeLeafHashesIfNecessary returns ErrInvalidLeafLen if tree leaves are not namespaced with the same namespace ID size the tree is configured with.
+// Any errors return by this method is irrecoverable and indicate an illegal state of the tree (n).
 func (n *NamespacedMerkleTree) computeLeafHashesIfNecessary() error {
 	// check whether all the hash of all the existing leaves are available
 	if len(n.leafHashes) < len(n.leaves) {

--- a/nmt.go
+++ b/nmt.go
@@ -473,7 +473,7 @@ func (n *NamespacedMerkleTree) computeRoot(start, end int) ([]byte, error) {
 		return rootHash, nil
 	case 1:
 		leafHash, err := n.treeHasher.HashLeaf(n.leaves[start])
-		if err != nil {
+		if err != nil { // this should never happen since leaves are added through the Push method, during which leaves formats are validated to make sure they are hashable.
 			return nil, fmt.Errorf("failed to hash leaf: %w", err)
 		}
 		if len(n.leafHashes) < len(n.leaves) {
@@ -484,15 +484,15 @@ func (n *NamespacedMerkleTree) computeRoot(start, end int) ([]byte, error) {
 	default:
 		k := getSplitPoint(end - start)
 		left, err := n.computeRoot(start, start+k)
-		if err != nil {
+		if err != nil { // this should never happen since leaves are added through the Push method, during which leaves formats are validated and their namespace IDs are checked to be sequential.
 			return nil, fmt.Errorf("failed to compute subtree root [%d, %d): %w", start, start+k, err)
 		}
 		right, err := n.computeRoot(start+k, end)
-		if err != nil {
+		if err != nil { // this should never happen since leaves are added through the Push method, during which leaves formats are validated and their namespace IDs are checked to be sequential.
 			return nil, fmt.Errorf("failed to compute subtree root [%d, %d): %w", start+k, end, err)
 		}
 		hash, err := n.treeHasher.HashNode(left, right)
-		if err != nil {
+		if err != nil { // this error should never happen since leaves are added through the Push method, during which leaves formats are validated and their namespace IDs are checked to be sequential.
 			return nil, fmt.Errorf("failed to compute subtree root [%d, %d): %w", left, right, err)
 		}
 		n.visit(hash, left, right)

--- a/nmt.go
+++ b/nmt.go
@@ -576,7 +576,7 @@ func (n *NamespacedMerkleTree) updateMinMaxID(id namespace.ID) {
 
 // computes the leaf hashes if not already done in a previous call of
 // NamespacedMerkleTree.Root()
-// computeLeafHashesIfNecessary returns ErrMismatchedNamespaceSize if tree leaves are not well-format i.e., not namespaced with the same namespace ID size the tree is configured with.
+// computeLeafHashesIfNecessary returns ErrMismatchedNamespaceSize if tree leaves are not well-formatted i.e., not namespaced with the same namespace ID size the tree is configured with.
 func (n *NamespacedMerkleTree) computeLeafHashesIfNecessary() error {
 	// check whether all the hash of all the existing leaves are available
 	if len(n.leafHashes) < len(n.leaves) {

--- a/nmt.go
+++ b/nmt.go
@@ -444,11 +444,11 @@ func (n *NamespacedMerkleTree) computeRoot(start, end int) ([]byte, error) {
 		k := getSplitPoint(end - start)
 		left, err := n.computeRoot(start, start+k)
 		if err != nil {
-			return nil, fmt.Errorf("failed to compute left subtree root [%d, %d): %w", start, start+k, err)
+			return nil, fmt.Errorf("failed to compute subtree root [%d, %d): %w", start, start+k, err)
 		}
 		right, err := n.computeRoot(start+k, end)
 		if err != nil {
-			return nil, fmt.Errorf("failed to compute right subtree root [%d, %d): %w", start+k, end, err)
+			return nil, fmt.Errorf("failed to compute subtree root [%d, %d): %w", start+k, end, err)
 		}
 		hash, err := n.treeHasher.HashNode(left, right)
 		if err != nil {

--- a/nmt.go
+++ b/nmt.go
@@ -454,13 +454,21 @@ func (n *NamespacedMerkleTree) Root() ([]byte, error) {
 }
 
 // MinNamespace returns the minimum namespace ID in this Namespaced Merkle Tree.
-func (n *NamespacedMerkleTree) MinNamespace() namespace.ID {
-	return MinNamespace(n.Root(), n.NamespaceSize())
+func (n *NamespacedMerkleTree) MinNamespace() (namespace.ID, error) {
+	r, err := n.Root()
+	if err != nil {
+		return nil, err
+	}
+	return MinNamespace(r, n.NamespaceSize()), nil
 }
 
 // MaxNamespace returns the maximum namespace ID in this Namespaced Merkle Tree.
-func (n *NamespacedMerkleTree) MaxNamespace() namespace.ID {
-	return MaxNamespace(n.Root(), n.NamespaceSize())
+func (n *NamespacedMerkleTree) MaxNamespace() (namespace.ID, error) {
+	r, err := n.Root()
+	if err != nil {
+		return nil, err
+	}
+	return MaxNamespace(r, n.NamespaceSize()), nil
 }
 
 // computeRoot calculates the namespace Merkle root for a tree/sub-tree that

--- a/nmt.go
+++ b/nmt.go
@@ -443,7 +443,6 @@ func (n *NamespacedMerkleTree) Root() ([]byte, error) {
 }
 
 // MinNamespace returns the minimum namespace ID in this Namespaced Merkle Tree.
-// MinNamespace returns one of the following errors:
 // Any errors returned by this method are irrecoverable and indicate an illegal state of the tree (n).
 func (n *NamespacedMerkleTree) MinNamespace() (namespace.ID, error) {
 	r, err := n.Root()
@@ -454,7 +453,6 @@ func (n *NamespacedMerkleTree) MinNamespace() (namespace.ID, error) {
 }
 
 // MaxNamespace returns the maximum namespace ID in this Namespaced Merkle Tree.
-// MaxNamespace returns one of the following errors:
 // Any errors returned by this method are irrecoverable and indicate an illegal state of the tree (n).
 func (n *NamespacedMerkleTree) MaxNamespace() (namespace.ID, error) {
 	r, err := n.Root()
@@ -466,7 +464,6 @@ func (n *NamespacedMerkleTree) MaxNamespace() (namespace.ID, error) {
 
 // computeRoot calculates the namespace Merkle root for a tree/sub-tree that
 // encompasses the leaves within the range of [start, end).
-// computeRoot returns one of the following errors:
 // Any errors returned by this method are irrecoverable and indicate an illegal state of the tree (n).
 func (n *NamespacedMerkleTree) computeRoot(start, end int) ([]byte, error) {
 	switch end - start {
@@ -547,8 +544,8 @@ func (n *NamespacedMerkleTree) updateNamespaceRanges() {
 // or if its namespace ID is smaller than the last leaf data in the tree (i.e.,
 // the n.leaves should be sorted in ascending order by their namespace ID).
 // validateAndExtractNamespace returns one of the following errors:
-// - ErrInvalidLeafLen: indicates the length of the namespaced data is smaller than the tree's NamespaceSize. This is an irrecoverable error.
-// - ErrInvalidPushOrder: indicates the namespace ID of the namespaced data is smaller than the last leaf data in the tree. This is an irrecoverable error.
+// - ErrInvalidLeafLen: indicates the length of the ndata is smaller than the tree's NamespaceSize.
+// - ErrInvalidPushOrder: indicates the namespace ID of the ndata is smaller than the last leaf data in the tree.
 func (n *NamespacedMerkleTree) validateAndExtractNamespace(ndata namespace.PrefixedData) (namespace.ID, error) {
 	nidSize := int(n.NamespaceSize())
 	if len(ndata) < nidSize {

--- a/nmt.go
+++ b/nmt.go
@@ -442,15 +442,15 @@ func (n *NamespacedMerkleTree) Push(namespacedData namespace.PrefixedData) error
 // been added through the use of the Push method. the returned byte slice is of
 // size 2* n.NamespaceSize + the underlying hash output size, and should be
 // parsed as minND || maxNID || hash
-func (n *NamespacedMerkleTree) Root() []byte {
+func (n *NamespacedMerkleTree) Root() ([]byte, error) {
 	if n.rawRoot == nil {
 		res, err := n.computeRoot(0, len(n.leaves))
 		if err != nil {
-			panic(err) // this is an illegal state, should never happen
+			return nil, err // this should never happen since leaves are validated in the Push method
 		}
 		n.rawRoot = res
 	}
-	return n.rawRoot
+	return n.rawRoot, nil
 }
 
 // MinNamespace returns the minimum namespace ID in this Namespaced Merkle Tree.

--- a/nmt_test.go
+++ b/nmt_test.go
@@ -1127,5 +1127,4 @@ func Test_computeLeafHashesIfNecessary_err(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/nmt_test.go
+++ b/nmt_test.go
@@ -877,7 +877,7 @@ func swap(slice [][]byte, i int, j int) {
 	slice[j] = temp
 }
 
-// Test_buildRangeProof_Err tests that buildRangeProof returns an error when the undelring tree has an invalid state e.g., leaves are not ordered by namespace ID or a leaf hash is corrupted.
+// Test_buildRangeProof_Err tests that buildRangeProof returns an error when the underlying tree has an invalid state e.g., leaves are not ordered by namespace ID or a leaf hash is corrupted.
 func Test_buildRangeProof_Err(t *testing.T) {
 	// create a nmt, 8 leaves namespaced sequentially from 1-8
 	treeWithCorruptLeafHash := exampleTreeWithEightLeaves()
@@ -904,8 +904,10 @@ func Test_buildRangeProof_Err(t *testing.T) {
 	}{
 		{"corrupt leaf hash", treeWithCorruptLeafHash, 4, 5, true, ErrInvalidNodeLen},
 		{"unordered leaf hashes", treeWithUnorderedLeafHashes, 4, 5, true, ErrUnorderedSiblings},
-		{"unordered leaf hashes", treeWithUnorderedLeafHashes, 1, 2, true, ErrUnorderedSiblings}, // the buildRangeProof should error out for any input range, not just the corrupted range
-		{"unordered leaf hashes", treeWithUnorderedLeafHashes, 7, 8, true, ErrUnorderedSiblings}, // the buildRangeProof should error out for any input range, not just the corrupted range
+		{"unordered leaf hashes", treeWithUnorderedLeafHashes, 1, 2, true, ErrUnorderedSiblings}, // for a tree with an unordered set of leaves, the buildRangeProof function  should produce an error for any input range,
+		// not just the corrupted range.
+		{"unordered leaf hashes", treeWithUnorderedLeafHashes, 7, 8, true, ErrUnorderedSiblings}, // for a tree with an unordered set of leaves, the buildRangeProof function  should produce an error for any input range,
+		// not just the corrupted range.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/nmt_test.go
+++ b/nmt_test.go
@@ -6,13 +6,14 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"math"
 	"math/rand"
 	"reflect"
 	"sort"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/celestiaorg/nmt/namespace"
 	"github.com/stretchr/testify/assert"
@@ -57,7 +58,9 @@ func ExampleNamespacedMerkleTree() {
 	}
 	// compute the root
 	root, err := tree.Root()
-	panic(err)
+	if err != nil {
+		panic("unexpected error")
+	}
 	// the root's min/max namespace is the min and max namespace of all leaves:
 	minNS := MinNamespace(root, tree.NamespaceSize())
 	maxNS := MaxNamespace(root, tree.NamespaceSize())

--- a/nmt_test.go
+++ b/nmt_test.go
@@ -1032,3 +1032,75 @@ func Test_Root_Error(t *testing.T) {
 		})
 	}
 }
+
+// Test_computeRoot_Error tests that the Root method returns an error when the underlying tree is in an invalid state, such as when the leaves are not ordered by namespace ID or when a leaf is corrupt.
+func Test_computeRoot_Error(t *testing.T) {
+	// create a nmt, 8 leaves namespaced sequentially from 1-8
+	treeWithCorruptLeaf := exampleTreeWithEightLeaves()
+	// corrupt a leaf
+	treeWithCorruptLeaf.leaves[4] = treeWithCorruptLeaf.leaves[4][:treeWithCorruptLeaf.NamespaceSize()-1]
+
+	// create a nmt, 8 leaves namespaced sequentially from 1-8
+	treeWithUnorderedLeaves := exampleTreeWithEightLeaves()
+	// swap the order of the 4th and the 5th leaf
+	swap(treeWithUnorderedLeaves.leaves, 4, 5)
+
+	tests := []struct {
+		name    string
+		tree    *NamespacedMerkleTree
+		wantErr bool
+		errType error
+	}{
+		{"corrupt leaf", treeWithCorruptLeaf, true, ErrInvalidLeafLen},
+		{"unordered leaves", treeWithUnorderedLeaves, true, ErrUnorderedSiblings},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.tree.Root()
+			assert.Equal(t, tt.wantErr, err != nil)
+			if tt.wantErr {
+				assert.True(t, errors.Is(err, tt.errType))
+			}
+		})
+	}
+}
+
+// Test_MinMaxNamespace_Err tests that the MinNamespace and MaxNamespace methods return an error when the underlying tree is in an invalid state, such as when the leaves are not ordered by namespace ID or when a leaf is corrupt.
+func Test_MinMaxNamespace_Err(t *testing.T) {
+	// create a nmt, 8 leaves namespaced sequentially from 1-8
+	treeWithCorruptLeaf := exampleTreeWithEightLeaves()
+	// corrupt a leaf
+	treeWithCorruptLeaf.leaves[4] = treeWithCorruptLeaf.leaves[4][:treeWithCorruptLeaf.NamespaceSize()-1]
+
+	// create a nmt, 8 leaves namespaced sequentially from 1-8
+	treeWithUnorderedLeaves := exampleTreeWithEightLeaves()
+	// swap the order of the 4th and the 5th leaf
+	swap(treeWithUnorderedLeaves.leaves, 4, 5)
+
+	tests := []struct {
+		name    string
+		tree    *NamespacedMerkleTree
+		wantErr bool
+		errType error
+	}{
+		{"corrupt leaf", treeWithCorruptLeaf, true, ErrInvalidLeafLen},
+		{"unordered leaves", treeWithUnorderedLeaves, true, ErrUnorderedSiblings},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.tree.MinNamespace()
+			assert.Equal(t, tt.wantErr, err != nil)
+			if tt.wantErr {
+				assert.True(t, errors.Is(err, tt.errType))
+			}
+
+			_, err = tt.tree.MaxNamespace()
+			assert.Equal(t, tt.wantErr, err != nil)
+			if tt.wantErr {
+				assert.True(t, errors.Is(err, tt.errType))
+			}
+
+		})
+	}
+
+}

--- a/nmt_test.go
+++ b/nmt_test.go
@@ -1102,3 +1102,30 @@ func Test_MinMaxNamespace_Err(t *testing.T) {
 		})
 	}
 }
+
+// Test_computeLeafHashesIfNecessary_err tests that the computeLeafHashesIfNecessary method returns an error when the underlying tree is in an invalid state, such as when a leaf is corrupt.
+func Test_computeLeafHashesIfNecessary_err(t *testing.T) {
+	// create a nmt, 8 leaves namespaced sequentially from 1-8
+	treeWithCorruptLeaf := exampleTreeWithEightLeaves()
+	// corrupt a leaf
+	treeWithCorruptLeaf.leaves[4] = treeWithCorruptLeaf.leaves[4][:treeWithCorruptLeaf.NamespaceSize()-1]
+
+	tests := []struct {
+		name    string
+		tree    *NamespacedMerkleTree
+		wantErr bool
+		errType error
+	}{
+		{"corrupt leaf", treeWithCorruptLeaf, true, ErrInvalidLeafLen},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.tree.computeLeafHashesIfNecessary()
+			assert.Equal(t, tt.wantErr, err != nil)
+			if tt.wantErr {
+				assert.True(t, errors.Is(err, tt.errType))
+			}
+		})
+	}
+
+}

--- a/nmt_test.go
+++ b/nmt_test.go
@@ -921,6 +921,11 @@ func Test_buildRangeProof_Err(t *testing.T) {
 // Test_ProveRange_Err tests that ProveRange returns an error when the underlying tree has an invalid state e.g., leaves are not ordered by namespace ID or a leaf hash is corrupted.
 func Test_ProveRange_Err(t *testing.T) {
 	// create a nmt, 8 leaves namespaced sequentially from 1-8
+	treeWithCorruptLeaf := exampleTreeWithEightLeaves()
+	// corrupt a leaf
+	treeWithCorruptLeaf.leaves[4] = treeWithCorruptLeaf.leaves[4][:treeWithCorruptLeaf.NamespaceSize()-1]
+
+	// create a nmt, 8 leaves namespaced sequentially from 1-8
 	treeWithCorruptLeafHash := exampleTreeWithEightLeaves()
 	err := treeWithCorruptLeafHash.computeLeafHashesIfNecessary()
 	require.NoError(t, err)
@@ -941,6 +946,7 @@ func Test_ProveRange_Err(t *testing.T) {
 		wantErr              bool
 		errType              error
 	}{
+		{"corrupt leaf", treeWithCorruptLeaf, 4, 5, true, ErrInvalidLeafLen},
 		{"corrupt leaf hash", treeWithCorruptLeafHash, 4, 5, true, ErrInvalidNodeLen},
 		{"unordered leaf hashes: the out of order leaf", treeWithUnorderedLeafHashes, 4, 5, true, ErrUnorderedSiblings},
 		{"unordered leaf hashes: first leaf", treeWithUnorderedLeafHashes, 1, 2, true, ErrUnorderedSiblings}, // for a tree with an unordered set of leaves, the ProveRange method  should produce an error for any input range,

--- a/nmt_test.go
+++ b/nmt_test.go
@@ -1099,8 +1099,6 @@ func Test_MinMaxNamespace_Err(t *testing.T) {
 			if tt.wantErr {
 				assert.True(t, errors.Is(err, tt.errType))
 			}
-
 		})
 	}
-
 }

--- a/nmt_test.go
+++ b/nmt_test.go
@@ -881,14 +881,16 @@ func swap(slice [][]byte, i int, j int) {
 func Test_buildRangeProof_Err(t *testing.T) {
 	// create a nmt, 8 leaves namespaced sequentially from 1-8
 	treeWithCorruptLeafHash := exampleTreeWithEightLeaves()
-	treeWithCorruptLeafHash.computeLeafHashesIfNecessary()
+	err := treeWithCorruptLeafHash.computeLeafHashesIfNecessary()
+	require.NoError(t, err)
 	// corrupt a leaf hash
 	treeWithCorruptLeafHash.leafHashes[4] = treeWithCorruptLeafHash.leafHashes[4][:treeWithCorruptLeafHash.NamespaceSize()]
 
 	// create a nmt, 8 leaves namespaced sequentially from 1-8
 	// swap the order of the 4th and the 5th leaf
 	treeWithUnorderedLeafHashes := exampleTreeWithEightLeaves()
-	treeWithUnorderedLeafHashes.computeLeafHashesIfNecessary()
+	err = treeWithUnorderedLeafHashes.computeLeafHashesIfNecessary()
+	require.NoError(t, err)
 	// reorder the leaves and leaf hashes
 	swap(treeWithUnorderedLeafHashes.leafHashes, 4, 5)
 	swap(treeWithUnorderedLeafHashes.leaves, 4, 5)
@@ -903,7 +905,7 @@ func Test_buildRangeProof_Err(t *testing.T) {
 		{"corrupt leaf hash", treeWithCorruptLeafHash, 4, 5, true, ErrInvalidNodeLen},
 		{"unordered leaf hashes", treeWithUnorderedLeafHashes, 4, 5, true, ErrUnorderedSiblings},
 		{"unordered leaf hashes", treeWithUnorderedLeafHashes, 1, 2, true, ErrUnorderedSiblings}, // the buildRangeProof should error out for any input range, not just the corrupted range
-		{"unordered leaf hashes", treeWithUnorderedLeafHashes, 7, 8, true, ErrUnorderedSiblings},
+		{"unordered leaf hashes", treeWithUnorderedLeafHashes, 7, 8, true, ErrUnorderedSiblings}, // the buildRangeProof should error out for any input range, not just the corrupted range
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/nmt_test.go
+++ b/nmt_test.go
@@ -886,9 +886,9 @@ func Test_buildRangeProof_Err(t *testing.T) {
 	// corrupt a leaf hash
 	treeWithCorruptLeafHash.leafHashes[4] = treeWithCorruptLeafHash.leafHashes[4][:treeWithCorruptLeafHash.NamespaceSize()]
 
-	// create a nmt, 8 leaves namespaced sequentially from 1-8
+	// create an NMT with 8 sequentially namespaced leaves, numbered from 1 to 8.
 	treeWithUnorderedLeafHashes := exampleTreeWithEightLeaves()
-	// swap the order of the 4th and the 5th leaf
+	// swap the positions of the 4th and 5th leaves
 	swap(treeWithUnorderedLeafHashes.leaves, 4, 5)
 	err = treeWithUnorderedLeafHashes.computeLeafHashesIfNecessary()
 	require.NoError(t, err)
@@ -920,21 +920,21 @@ func Test_buildRangeProof_Err(t *testing.T) {
 
 // Test_ProveRange_Err tests that ProveRange returns an error when the underlying tree has an invalid state e.g., leaves are not ordered by namespace ID or a leaf hash is corrupted.
 func Test_ProveRange_Err(t *testing.T) {
-	// create a nmt, 8 leaves namespaced sequentially from 1-8
+	// create an NMT with 8 sequentially namespaced leaves, numbered from 1 to 8.
 	treeWithCorruptLeaf := exampleTreeWithEightLeaves()
 	// corrupt a leaf
 	treeWithCorruptLeaf.leaves[4] = treeWithCorruptLeaf.leaves[4][:treeWithCorruptLeaf.NamespaceSize()-1]
 
-	// create a nmt, 8 leaves namespaced sequentially from 1-8
+	// create an NMT with 8 sequentially namespaced leaves, numbered from 1 to 8.
 	treeWithCorruptLeafHash := exampleTreeWithEightLeaves()
 	err := treeWithCorruptLeafHash.computeLeafHashesIfNecessary()
 	require.NoError(t, err)
 	// corrupt a leaf hash
 	treeWithCorruptLeafHash.leafHashes[4] = treeWithCorruptLeafHash.leafHashes[4][:treeWithCorruptLeafHash.NamespaceSize()]
 
-	// create a nmt, 8 leaves namespaced sequentially from 1-8
+	// create an NMT with 8 sequentially namespaced leaves, numbered from 1 to 8.
 	treeWithUnorderedLeafHashes := exampleTreeWithEightLeaves()
-	// swap the order of the 4th and the 5th leaf
+	// swap the positions of the 4th and 5th leaves
 	swap(treeWithUnorderedLeafHashes.leaves, 4, 5)
 	err = treeWithUnorderedLeafHashes.computeLeafHashesIfNecessary()
 	require.NoError(t, err)
@@ -967,22 +967,21 @@ func Test_ProveRange_Err(t *testing.T) {
 
 // The Test_ProveNamespace_Err function tests that ProveNamespace returns an error when the underlying tree is in an invalid state, such as when the leaves are not ordered by namespace ID or when a leaf hash is corrupt.
 func Test_ProveNamespace_Err(t *testing.T) {
-	// create a nmt, 8 leaves namespaced sequentially from 1-8
+	// create an NMT with 8 sequentially namespaced leaves, numbered from 1 to 8.
 	treeWithCorruptLeaf := exampleTreeWithEightLeaves()
 	// corrupt a leaf
 	treeWithCorruptLeaf.leaves[4] = treeWithCorruptLeaf.leaves[4][:treeWithCorruptLeaf.NamespaceSize()-1]
 
-	// create a nmt, 8 leaves namespaced sequentially from 1-8
+	// create an NMT with 8 sequentially namespaced leaves, numbered from 1 to 8.
 	treeWithCorruptLeafHash := exampleTreeWithEightLeaves()
 	err := treeWithCorruptLeafHash.computeLeafHashesIfNecessary()
 	require.NoError(t, err)
 	// corrupt a leaf hash
 	treeWithCorruptLeafHash.leafHashes[4] = treeWithCorruptLeafHash.leafHashes[4][:treeWithCorruptLeafHash.NamespaceSize()]
 
-	// create a nmt, 8 leaves namespaced sequentially from 1-8
-	// swap the order of the 4th and the 5th leaf
+	// create an NMT with 8 sequentially namespaced leaves, numbered from 1 to 8.
 	treeWithUnorderedLeafHashes := exampleTreeWithEightLeaves()
-	// reorder the leaves
+	// swap the positions of the 4th and 5th leaves
 	swap(treeWithUnorderedLeafHashes.leaves, 4, 5)
 	err = treeWithUnorderedLeafHashes.computeLeafHashesIfNecessary()
 	require.NoError(t, err)
@@ -1015,14 +1014,14 @@ func Test_ProveNamespace_Err(t *testing.T) {
 
 // Test_Root_Error tests that the Root method returns an error when the underlying tree is in an invalid state, such as when the leaves are not ordered by namespace ID or when a leaf is corrupt.
 func Test_Root_Error(t *testing.T) {
-	// create a nmt, 8 leaves namespaced sequentially from 1-8
+	// create an NMT with 8 sequentially namespaced leaves, numbered from 1 to 8.
 	treeWithCorruptLeaf := exampleTreeWithEightLeaves()
 	// corrupt a leaf
 	treeWithCorruptLeaf.leaves[4] = treeWithCorruptLeaf.leaves[4][:treeWithCorruptLeaf.NamespaceSize()-1]
 
-	// create a nmt, 8 leaves namespaced sequentially from 1-8
+	// create an NMT with 8 sequentially namespaced leaves, numbered from 1 to 8.
 	treeWithUnorderedLeaves := exampleTreeWithEightLeaves()
-	// swap the order of the 4th and the 5th leaf
+	// swap the positions of the 4th and 5th leaves
 	swap(treeWithUnorderedLeaves.leaves, 4, 5)
 
 	tests := []struct {
@@ -1047,14 +1046,14 @@ func Test_Root_Error(t *testing.T) {
 
 // Test_computeRoot_Error tests that the Root method returns an error when the underlying tree is in an invalid state, such as when the leaves are not ordered by namespace ID or when a leaf is corrupt.
 func Test_computeRoot_Error(t *testing.T) {
-	// create a nmt, 8 leaves namespaced sequentially from 1-8
+	// create an NMT with 8 sequentially namespaced leaves, numbered from 1 to 8.
 	treeWithCorruptLeaf := exampleTreeWithEightLeaves()
 	// corrupt a leaf
 	treeWithCorruptLeaf.leaves[4] = treeWithCorruptLeaf.leaves[4][:treeWithCorruptLeaf.NamespaceSize()-1]
 
-	// create a nmt, 8 leaves namespaced sequentially from 1-8
+	// create an NMT with 8 sequentially namespaced leaves, numbered from 1 to 8.
 	treeWithUnorderedLeaves := exampleTreeWithEightLeaves()
-	// swap the order of the 4th and the 5th leaf
+	// swap the positions of the 4th and 5th leaves
 	swap(treeWithUnorderedLeaves.leaves, 4, 5)
 
 	tests := []struct {
@@ -1079,14 +1078,14 @@ func Test_computeRoot_Error(t *testing.T) {
 
 // Test_MinMaxNamespace_Err tests that the MinNamespace and MaxNamespace methods return an error when the underlying tree is in an invalid state, such as when the leaves are not ordered by namespace ID or when a leaf is corrupt.
 func Test_MinMaxNamespace_Err(t *testing.T) {
-	// create a nmt, 8 leaves namespaced sequentially from 1-8
+	// create an NMT with 8 sequentially namespaced leaves, numbered from 1 to 8.
 	treeWithCorruptLeaf := exampleTreeWithEightLeaves()
 	// corrupt a leaf
 	treeWithCorruptLeaf.leaves[4] = treeWithCorruptLeaf.leaves[4][:treeWithCorruptLeaf.NamespaceSize()-1]
 
-	// create a nmt, 8 leaves namespaced sequentially from 1-8
+	// create an NMT with 8 sequentially namespaced leaves, numbered from 1 to 8.
 	treeWithUnorderedLeaves := exampleTreeWithEightLeaves()
-	// swap the order of the 4th and the 5th leaf
+	// swap the positions of the 4th and 5th leaves
 	swap(treeWithUnorderedLeaves.leaves, 4, 5)
 
 	tests := []struct {
@@ -1117,7 +1116,7 @@ func Test_MinMaxNamespace_Err(t *testing.T) {
 
 // Test_computeLeafHashesIfNecessary_err tests that the computeLeafHashesIfNecessary method returns an error when the underlying tree is in an invalid state, such as when a leaf is corrupt.
 func Test_computeLeafHashesIfNecessary_err(t *testing.T) {
-	// create a nmt, 8 leaves namespaced sequentially from 1-8
+	// create an NMT with 8 sequentially namespaced leaves, numbered from 1 to 8.
 	treeWithCorruptLeaf := exampleTreeWithEightLeaves()
 	// corrupt a leaf
 	treeWithCorruptLeaf.leaves[4] = treeWithCorruptLeaf.leaves[4][:treeWithCorruptLeaf.NamespaceSize()-1]

--- a/nmt_test.go
+++ b/nmt_test.go
@@ -962,6 +962,11 @@ func Test_ProveRange_Err(t *testing.T) {
 // The Test_ProveNamespace_Err function tests that ProveNamespace returns an error when the underlying tree is in an invalid state, such as when the leaves are not ordered by namespace ID or when a leaf hash is corrupt.
 func Test_ProveNamespace_Err(t *testing.T) {
 	// create a nmt, 8 leaves namespaced sequentially from 1-8
+	treeWithCorruptLeaf := exampleTreeWithEightLeaves()
+	// corrupt a leaf
+	treeWithCorruptLeaf.leaves[4] = treeWithCorruptLeaf.leaves[4][:treeWithCorruptLeaf.NamespaceSize()-1]
+
+	// create a nmt, 8 leaves namespaced sequentially from 1-8
 	treeWithCorruptLeafHash := exampleTreeWithEightLeaves()
 	err := treeWithCorruptLeafHash.computeLeafHashesIfNecessary()
 	require.NoError(t, err)
@@ -983,6 +988,7 @@ func Test_ProveNamespace_Err(t *testing.T) {
 		wantErr bool
 		errType error
 	}{
+		{"corrupt leaf", treeWithCorruptLeaf, namespace.ID{5, 5}, true, ErrInvalidLeafLen},
 		{"corrupt leaf hash", treeWithCorruptLeafHash, namespace.ID{5, 5}, true, ErrInvalidNodeLen},
 		{"unordered leaf hashes: the queried namespace falls in the corrupted range", treeWithUnorderedLeafHashes, namespace.ID{5, 5}, true, ErrUnorderedSiblings},
 		{"unordered leaf hashes: query for the first namespace", treeWithUnorderedLeafHashes, namespace.ID{1, 1}, true, ErrUnorderedSiblings}, // for a tree with an unordered set of leaves,

--- a/proof.go
+++ b/proof.go
@@ -195,6 +195,10 @@ func (proof Proof) VerifyNamespace(h hash.Hash, nID namespace.ID, data [][]byte,
 // the completeness of the proof by verifying that there is no leaf in the Merkle
 // tree represented by the root parameter that matches the namespace ID nID
 // but is not present in the leafHashes list.
+// verifyLeafHashed returns one of the following errors:
+// - ErrFailedCompletenessCheck: if the completeness check of the proof fails.
+// - ErrInvalidNodeLen: if the leafHashes or the proof.nodes are not namespace hashes.
+// - ErrUnorderedSiblings: if the nodes of the proof or the leafHashes are not in order according to their namespace IDs.
 func (proof Proof) verifyLeafHashes(nth *Hasher, verifyCompleteness bool, nID namespace.ID, leafHashes [][]byte, root []byte) (bool, error) {
 	var leafIndex uint64
 	// leftSubtrees is to be populated by the subtree roots upto [0, r.Start)
@@ -215,13 +219,13 @@ func (proof Proof) verifyLeafHashes(nth *Hasher, verifyCompleteness bool, nID na
 		for _, subtree := range leftSubtrees {
 			leftSubTreeMax := MaxNamespace(subtree, nth.NamespaceSize())
 			if nID.LessOrEqual(namespace.ID(leftSubTreeMax)) {
-				return false, ErrFailedCompletenessCheck // TODO provide more context
+				return false, ErrFailedCompletenessCheck
 			}
 		}
 		for _, subtree := range rightSubtrees {
 			rightSubTreeMin := MinNamespace(subtree, nth.NamespaceSize())
 			if namespace.ID(rightSubTreeMin).LessOrEqual(nID) {
-				return false, ErrFailedCompletenessCheck // TODO provide more context
+				return false, ErrFailedCompletenessCheck
 			}
 		}
 	}

--- a/proof.go
+++ b/proof.go
@@ -191,16 +191,15 @@ func (proof Proof) VerifyNamespace(h hash.Hash, nID namespace.ID, data [][]byte,
 }
 
 // The verifyLeafHashes function checks whether the given proof is a valid Merkle
-// range proof for the leaves in the leafHashes input.
+// range proof for the leaves in the leafHashes input. It returns true or false accordingly.
+// If there is an issue during the proof verification e.g., a node does not conform to the namespace hash format, then a proper error is returned to indicate the root cause of the issue.
 // The leafHashes parameter is a list of leaf hashes, where each leaf hash is represented
 // by a byte slice.
 // If the verifyCompleteness parameter is set to true, the function also checks
 // the completeness of the proof by verifying that there is no leaf in the
 // tree represented by the root parameter that matches the namespace ID nID
 // but is not present in the leafHashes list.
-// verifyLeafHashes returns  verified=true if the proof is valid, false otherwise.
-// In verified=false, the value of proofFailureCause indicates the cause of the unsuccessful proof verification.
-func (proof Proof) verifyLeafHashes(nth *Hasher, verifyCompleteness bool, nID namespace.ID, leafHashes [][]byte, root []byte) (verified bool, proofFailureCause error) {
+func (proof Proof) verifyLeafHashes(nth *Hasher, verifyCompleteness bool, nID namespace.ID, leafHashes [][]byte, root []byte) (bool, error) {
 	var leafIndex uint64
 	// leftSubtrees is to be populated by the subtree roots upto [0, r.Start)
 	leftSubtrees := make([][]byte, 0, len(proof.nodes))

--- a/proof.go
+++ b/proof.go
@@ -160,21 +160,17 @@ func (proof Proof) VerifyNamespace(h hash.Hash, nID namespace.ID, data [][]byte,
 		// collect leaf hashes from provided data and do some sanity checks:
 		hashLeafFunc := nth.HashLeaf
 		for _, gotLeaf := range data {
-			if len(gotLeaf) < int(nIDLen) {
-				// conflicting namespace sizes
+			if nth.ValidateLeaf(gotLeaf) != nil {
 				return false
 			}
-			gotLeafNid := namespace.ID(gotLeaf[:nIDLen])
-			if !gotLeafNid.Equal(nID) {
+			// check whether the namespace ID of the data matches the queried nID
+			if gotLeafNid := namespace.ID(gotLeaf[:nIDLen]); !gotLeafNid.Equal(nID) {
 				// conflicting namespace IDs in data
 				return false
 			}
-			leafData := append(
-				gotLeafNid, gotLeaf[nIDLen:]...,
-			)
 			// hash the leaf data
-			leafHash, err := hashLeafFunc(leafData)
-			if err != nil {
+			leafHash, err := hashLeafFunc(gotLeaf)
+			if err != nil { // this can never happen due to the initial validation of the leaf at the beginning of the loop
 				return false
 			}
 			gotLeafHashes = append(gotLeafHashes, leafHash)

--- a/proof.go
+++ b/proof.go
@@ -10,9 +10,7 @@ import (
 	"github.com/celestiaorg/nmt/namespace"
 )
 
-var (
-	ErrFailedCompletenessCheck = errors.New("failed completeness check")
-)
+var ErrFailedCompletenessCheck = errors.New("failed completeness check")
 
 // Proof represents a namespace proof of a namespace.ID in an NMT. In case this
 // proof proves the absence of a namespace.ID in a tree it also contains the

--- a/proof.go
+++ b/proof.go
@@ -10,6 +10,7 @@ import (
 	"github.com/celestiaorg/nmt/namespace"
 )
 
+// ErrFailedCompletenessCheck indicates that the verification of a namespace proof failed due to the lack of completeness property.
 var ErrFailedCompletenessCheck = errors.New("failed completeness check")
 
 // Proof represents a namespace proof of a namespace.ID in an NMT. In case this
@@ -81,6 +82,8 @@ func (proof Proof) IsNonEmptyRange() bool {
 	return proof.start >= 0 && proof.start < proof.end
 }
 
+// IsMaxNamespaceIDIgnored returns true if the proof has been created under the ignore max namespace logic.
+// see ./docs/nmt-lib.md for more details.
 func (proof Proof) IsMaxNamespaceIDIgnored() bool {
 	return proof.isMaxNamespaceIDIgnored
 }

--- a/proof.go
+++ b/proof.go
@@ -297,20 +297,20 @@ func (proof Proof) verifyLeafHashes(nth *Hasher, verifyCompleteness bool, nID na
 }
 
 // VerifyInclusion checks that the inclusion proof is valid by using leaf data
-// and the provided proof to regenerate and compare the root. Note that the leaf
-// data should not contain the prefixed namespace, unlike the tree.Push method,
+// and the provided proof to regenerate and compare the root. Note that the leavesWithoutNamespace data should not contain the prefixed namespace, unlike the tree.Push method,
 // which takes prefixed data. All leaves implicitly have the same namespace ID:
 // `nid`.
-func (proof Proof) VerifyInclusion(h hash.Hash, nid namespace.ID, leaves [][]byte, root []byte) bool {
+func (proof Proof) VerifyInclusion(h hash.Hash, nid namespace.ID, leavesWithoutNamespace [][]byte, root []byte) bool {
 	nth := NewNmtHasher(h, nid.Size(), proof.isMaxNamespaceIDIgnored)
-	hashes := make([][]byte, len(leaves))
-	for i, d := range leaves {
+	hashes := make([][]byte, len(leavesWithoutNamespace))
+	for i, d := range leavesWithoutNamespace {
+		// prepend the namespace to the leaf data
 		leafData := append(
 			append(make([]byte, 0, len(d)+len(nid)), nid...), d...,
 		)
 		res, err := nth.HashLeaf(leafData)
 		if err != nil {
-			return false
+			return false // this never can happen since the leafData is guaranteed to be namespaced
 		}
 		hashes[i] = res
 	}

--- a/proof.go
+++ b/proof.go
@@ -192,14 +192,12 @@ func (proof Proof) VerifyNamespace(h hash.Hash, nID namespace.ID, data [][]byte,
 // The leafHashes parameter is a list of leaf hashes, where each leaf hash is represented
 // by a byte slice.
 // If the verifyCompleteness parameter is set to true, the function also checks
-// the completeness of the proof by verifying that there is no leaf in the Merkle
+// the completeness of the proof by verifying that there is no leaf in the
 // tree represented by the root parameter that matches the namespace ID nID
 // but is not present in the leafHashes list.
-// verifyLeafHashed returns one of the following errors:
-// - ErrFailedCompletenessCheck: if the completeness check of the proof fails.
-// - ErrInvalidNodeLen: if the leafHashes or the proof.nodes are not namespace hashes.
-// - ErrUnorderedSiblings: if the nodes of the proof or the leafHashes are not in order according to their namespace IDs.
-func (proof Proof) verifyLeafHashes(nth *Hasher, verifyCompleteness bool, nID namespace.ID, leafHashes [][]byte, root []byte) (bool, error) {
+// verifyLeafHashes returns  verified=true if the proof is valid, false otherwise.
+// In verified=false, the value of proofFailureCause indicates the cause of the unsuccessful proof verification.
+func (proof Proof) verifyLeafHashes(nth *Hasher, verifyCompleteness bool, nID namespace.ID, leafHashes [][]byte, root []byte) (verified bool, proofFailureCause error) {
 	var leafIndex uint64
 	// leftSubtrees is to be populated by the subtree roots upto [0, r.Start)
 	leftSubtrees := make([][]byte, 0, len(proof.nodes))

--- a/proof_test.go
+++ b/proof_test.go
@@ -3,6 +3,7 @@ package nmt
 import (
 	"bytes"
 	"crypto/sha256"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/celestiaorg/nmt/namespace"

--- a/proof_test.go
+++ b/proof_test.go
@@ -3,8 +3,9 @@ package nmt
 import (
 	"bytes"
 	"crypto/sha256"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/celestiaorg/nmt/namespace"
 )
@@ -45,7 +46,7 @@ func TestProof_VerifyNamespace_False(t *testing.T) {
 	leafIndex := 3
 	inclusionProofOfLeafIndex, err := n.buildRangeProof(leafIndex, leafIndex+1)
 	require.NoError(t, err)
-	n.computeLeafHashesIfNecessary()
+	require.NoError(t, n.computeLeafHashesIfNecessary())
 	leafHash := n.leafHashes[leafIndex] // the only data item with namespace ID = 2 in the constructed tree is at index 3
 	invalidAbsenceProof := NewAbsenceProof(leafIndex, leafIndex+1, inclusionProofOfLeafIndex, leafHash, false)
 

--- a/proof_test.go
+++ b/proof_test.go
@@ -220,7 +220,7 @@ func Test_verifyLeafHashes_Err(t *testing.T) {
 	proof5, err := nmt.ProveNamespace(nID5)
 	require.NoError(t, err)
 	// corrupt the leafHash so that the proof verification fails during the root computation.
-	// note that the leaf at index 4 has the namespace ID of 5
+	// note that the leaf at index 4 has the namespace ID of 5.
 	leafHash5 := nmt.leafHashes[4][:nmt.NamespaceSize()]
 
 	// create nmt proof for namespace ID 4

--- a/proof_test.go
+++ b/proof_test.go
@@ -3,8 +3,9 @@ package nmt
 import (
 	"bytes"
 	"crypto/sha256"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/stretchr/testify/require"
 
@@ -239,7 +240,5 @@ func Test_verifyLeafHashes_Err(t *testing.T) {
 			_, err := tt.proof.verifyLeafHashes(tt.Hasher, tt.verifyCompleteness, tt.nID, tt.leafHashes, tt.root)
 			assert.Equal(t, tt.wantErr, err != nil)
 		})
-
 	}
-
 }

--- a/proof_test.go
+++ b/proof_test.go
@@ -52,6 +52,11 @@ func TestProof_VerifyNamespace_False(t *testing.T) {
 	// inclusion proof of leaf index 10
 	incProof10, err := n.buildRangeProof(10, 11)
 	require.NoError(t, err)
+
+	// root
+	root, err := n.Root()
+	require.NoError(t, err)
+
 	tests := []struct {
 		name  string
 		proof Proof
@@ -60,52 +65,52 @@ func TestProof_VerifyNamespace_False(t *testing.T) {
 	}{
 		{
 			"invalid nid (too long)", validProof,
-			args{[]byte{0, 0, 0, 0}, pushedZeroNs, n.Root()},
+			args{[]byte{0, 0, 0, 0}, pushedZeroNs, root},
 			false,
 		},
 		{
 			"invalid leaf data (too short)", validProof,
-			args{[]byte{0, 0, 0}, [][]byte{{0, 1}}, n.Root()},
+			args{[]byte{0, 0, 0}, [][]byte{{0, 1}}, root},
 			false,
 		},
 		{
 			"mismatching IDs in data", validProof,
-			args{[]byte{0, 0, 0}, append(append([][]byte(nil), pushedZeroNs...), []byte{1, 1, 1}), n.Root()},
+			args{[]byte{0, 0, 0}, append(append([][]byte(nil), pushedZeroNs...), []byte{1, 1, 1}), root},
 			false,
 		},
 		{
 			"added another leaf", validProof,
-			args{[]byte{0, 0, 0}, append(append([][]byte(nil), pushedZeroNs...), []byte{0, 0, 0}), n.Root()},
+			args{[]byte{0, 0, 0}, append(append([][]byte(nil), pushedZeroNs...), []byte{0, 0, 0}), root},
 			false,
 		},
 		{
 			"remove one leaf, errors", validProof,
-			args{[]byte{0, 0, 0}, pushedZeroNs[:len(pushedZeroNs)-1], n.Root()},
+			args{[]byte{0, 0, 0}, pushedZeroNs[:len(pushedZeroNs)-1], root},
 			false,
 		},
 		{
 			"remove one leaf & update proof range, errors", NewInclusionProof(validProof.Start(), validProof.End()-1, validProof.Nodes(), false),
-			args{[]byte{0, 0, 0}, pushedZeroNs[:len(pushedZeroNs)-1], n.Root()},
+			args{[]byte{0, 0, 0}, pushedZeroNs[:len(pushedZeroNs)-1], root},
 			false,
 		},
 		{
 			"incomplete namespace proof (right)", incompleteFirstNs,
-			args{[]byte{0, 0, 0}, pushedZeroNs[:len(pushedZeroNs)-1], n.Root()},
+			args{[]byte{0, 0, 0}, pushedZeroNs[:len(pushedZeroNs)-1], root},
 			false,
 		},
 		{
 			"incomplete namespace proof (left)", NewInclusionProof(10, 11, incProof10, false),
-			args{[]byte{0, 0, 8}, pushedLastNs[1:], n.Root()},
+			args{[]byte{0, 0, 8}, pushedLastNs[1:], root},
 			false,
 		},
 		{
 			"remove all leaves, errors", validProof,
-			args{[]byte{0, 0, 0}, pushedZeroNs[:len(pushedZeroNs)-2], n.Root()},
+			args{[]byte{0, 0, 0}, pushedZeroNs[:len(pushedZeroNs)-2], root},
 			false,
 		},
 		{
 			"invalid absence proof of an existing nid", invalidAbsenceProof,
-			args{[]byte{0, 0, 2}, [][]byte{}, n.Root()},
+			args{[]byte{0, 0, 2}, [][]byte{}, root},
 			false,
 		},
 	}
@@ -154,6 +159,9 @@ func TestProof_MultipleLeaves(t *testing.T) {
 		}
 	}
 
+	root, err := n.Root()
+	require.NoError(t, err)
+
 	type args struct {
 		start, end int
 		root       []byte
@@ -164,16 +172,16 @@ func TestProof_MultipleLeaves(t *testing.T) {
 		want bool
 	}{
 		{
-			"3rd through 5th leaf", args{2, 4, n.Root()}, true,
+			"3rd through 5th leaf", args{2, 4, root}, true,
 		},
 		{
-			"single leaf", args{2, 3, n.Root()}, true,
+			"single leaf", args{2, 3, root}, true,
 		},
 		{
-			"first leaf", args{0, 1, n.Root()}, true,
+			"first leaf", args{0, 1, root}, true,
 		},
 		{
-			"most leaves", args{0, 7, n.Root()}, true,
+			"most leaves", args{0, 7, root}, true,
 		},
 		{
 			"most leaves", args{0, 7, bytes.Repeat([]byte{1}, 48)}, false,

--- a/proof_test.go
+++ b/proof_test.go
@@ -268,7 +268,7 @@ func TestVerifyInclusion_False(t *testing.T) {
 	proof4, err := nmt.ProveNamespace(nID4)
 	require.NoError(t, err)
 	// proof4 is the inclusion proof for the leaf at index 3
-	leaf4WONamespace := nmt.leaves[3][nmt.NamespaceSize():] // the VerifyInclusion function expects the leaf without the namespace ID
+	leaf4WithoutNamespace := nmt.leaves[3][nmt.NamespaceSize():] // the VerifyInclusion function expects the leaf without the namespace ID, that's why we cut the namespace ID from the leaf.
 
 	// corrupt the last node in the proof4.nodes, it resides on the right side of the proof4.end index.
 	// this test scenario makes the VerifyInclusion fail when constructing the tree root from the
@@ -287,7 +287,7 @@ func TestVerifyInclusion_False(t *testing.T) {
 		args   args
 		result bool
 	}{
-		{" wrong proof.nodes: the last node has an incorrect format", proof4, args{hasher, nID4, [][]byte{leaf4WONamespace}, root}, false},
+		{" wrong proof.nodes: the last node has an incorrect format", proof4, args{hasher, nID4, [][]byte{leaf4WithoutNamespace}, root}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/proof_test.go
+++ b/proof_test.go
@@ -32,7 +32,7 @@ func TestProof_VerifyNamespace_False(t *testing.T) {
 	if err != nil {
 		t.Fatalf("invalid test setup: error on ProveNamespace(): %v", err)
 	}
-	// inclusion proof of leaf index 0
+	// inclusion proof of the leaf index 0
 	incProof0, err := n.buildRangeProof(0, 1)
 	require.NoError(t, err)
 	incompleteFirstNs := NewInclusionProof(0, 1, incProof0, false)
@@ -52,7 +52,7 @@ func TestProof_VerifyNamespace_False(t *testing.T) {
 	leafHash := n.leafHashes[leafIndex] // the only data item with namespace ID = 2 in the constructed tree is at index 3
 	invalidAbsenceProof := NewAbsenceProof(leafIndex, leafIndex+1, inclusionProofOfLeafIndex, leafHash, false)
 
-	// inclusion proof of leaf index 10
+	// inclusion proof of the leaf index 10
 	incProof10, err := n.buildRangeProof(10, 11)
 	require.NoError(t, err)
 
@@ -215,13 +215,12 @@ func Test_verifyLeafHashes_Err(t *testing.T) {
 	root, err := nmt.Root()
 	require.NoError(t, err)
 
-	// create a nmt proof
+	// create an NMT proof
 	nID5 := namespace.ID{5, 5}
 	proof5, err := nmt.ProveNamespace(nID5)
 	require.NoError(t, err)
-	// corrupt the leafHash so that the proof verification fails
-	// it causes failure in the root computation when verifying the proof
-	// leaf at index 4 has the namespace ID of 5
+	// corrupt the leafHash so that the proof verification fails during the root computation.
+	// note that the leaf at index 4 has the namespace ID of 5
 	leafHash5 := nmt.leafHashes[4][:nmt.NamespaceSize()]
 
 	// create nmt proof for namespace ID 4
@@ -246,7 +245,7 @@ func Test_verifyLeafHashes_Err(t *testing.T) {
 	}{
 		{" wrong leafHash: not namespaced", proof5, hasher, true, nID5, [][]byte{leafHash5}, root, true},
 		{" wrong leafHash: incorrect namespace", proof5, hasher, true, nID5, [][]byte{{10, 10, 10, 10}}, root, true},
-		{" wrong proof.nodes: corrupt last node", proof4, hasher, false, nID4, [][]byte{leafHash4}, root, true},
+		{" wrong proof.nodes: the last node has an incorrect format", proof4, hasher, false, nID4, [][]byte{leafHash4}, root, true},
 		//  the verifyCompleteness parameter in the verifyProof function should be set to false in order to bypass nodes correctness check during the completeness verification (otherwise it panics).
 	}
 	for _, tt := range tests {

--- a/proof_test.go
+++ b/proof_test.go
@@ -228,8 +228,9 @@ func Test_verifyLeafHashes_Err(t *testing.T) {
 	nID4 := namespace.ID{4, 4}
 	proof4, err := nmt.ProveNamespace(nID4)
 	require.NoError(t, err)
-	// corrupt the last node in the proof4.nodes, it resides on the right side of the proof4.end index
-	// it causes failure in the root computation when verifying the proof
+	// corrupt the last node in the proof4.nodes, it resides on the right side of the proof4.end index.
+	// this test scenario makes the proof verification fail when constructing the tree root from the
+	// computed subtree root and the proof.nodes on the right side of the proof.end index.
 	proof4.nodes[2] = proof4.nodes[2][:nmt.NamespaceSize()-1]
 	leafHash4 := nmt.leafHashes[3]
 
@@ -246,8 +247,7 @@ func Test_verifyLeafHashes_Err(t *testing.T) {
 		{" wrong leafHash: not namespaced", proof5, hasher, true, nID5, [][]byte{leafHash5}, root, true},
 		{" wrong leafHash: incorrect namespace", proof5, hasher, true, nID5, [][]byte{{10, 10, 10, 10}}, root, true},
 		{" wrong proof.nodes: corrupt last node", proof4, hasher, false, nID4, [][]byte{leafHash4}, root, true},
-		//  the verifyCompleteness parameter in the verifyProof function should be set to false in order to ensure the faulty proof fails when constructing the tree root from the computed subtree root and the proof.
-		//  nodes on the right side of the proof.end index.
+		//  the verifyCompleteness parameter in the verifyProof function should be set to false in order to bypass nodes correctness check during the completeness verification (otherwise it panics).
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/proof_test.go
+++ b/proof_test.go
@@ -244,7 +244,7 @@ func Test_verifyLeafHashes_Err(t *testing.T) {
 		wantErr            bool
 	}{
 		{" wrong leafHash: not namespaced", proof5, hasher, true, nID5, [][]byte{leafHash5}, root, true},
-		{" wrong leafHash: incorrect namespace", proof5, hasher, true, nID5, [][]byte{[]byte{10, 10, 10, 10}}, root, true},
+		{" wrong leafHash: incorrect namespace", proof5, hasher, true, nID5, [][]byte{{10, 10, 10, 10}}, root, true},
 		{" wrong proof.nodes: corrupt last node", proof4, hasher, false, nID4, [][]byte{leafHash4}, root, true},
 		//  the verifyCompleteness parameter in the verifyProof function should be set to false in order to ensure the faulty proof fails when constructing the tree root from the computed subtree root and the proof.
 		//  nodes on the right side of the proof.end index.


### PR DESCRIPTION
## Overview
Closes #109 and #99.
This pull request ensures that the `HashNode` and `HashLeaf` functions return errors instead of panicking, and that caller functions properly handle any emitted errors. When generating proofs, any hashing errors are propagated with additional context. During verification, hashing errors are treated as unsuccessful proof verification.

Note that in this PR, the term `Irrecoverable errors` used to describe errors that any number of retries can correct the them. 

## Checklist


- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
