### PR TITLE
VerifyInclusion InvalidInput

### DIFF
--- a/proof_test.go
+++ b/proof_test.go
@@ -236,6 +236,7 @@ func TestProof_VerifyInclusion_InvalidInput(t *testing.T) {
 	}
 
 	rawDataForNSOne := [][]byte{[]byte("leaf_0"), []byte("leaf_1")}
+	root, _ := n.Root()
 	tests := []struct {
 		name  string
 		proof Proof
@@ -244,8 +245,8 @@ func TestProof_VerifyInclusion_InvalidInput(t *testing.T) {
 	}{
 		{
 			"invalid nid (too long)", validProof,
-			args{[]byte{1, 1}, rawDataForNSOne, n.Root()},
-			false,
+			args{[]byte{1, 1}, rawDataForNSOne, root},
+			true,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This is a PR that includes a test for the issue [ValidateInclusion function can panic if it is called with an invalid nid](https://github.com/celestiaorg/nmt/issues/157).

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
