### PR TITLE
feat!: add an additional constraint of empty leafHash field to the empty proof definition

### DIFF
--- a/proof.go
+++ b/proof.go
@@ -66,7 +66,7 @@ func (proof Proof) Nodes() [][]byte {
 // IsOfAbsence returns true if this proof proves the absence of leaves of a
 // namespace in the tree.
 func (proof Proof) IsOfAbsence() bool {
-	return len(proof.leafHash) > 0 && !(proof.start < 0) && (proof.end == proof.start+1)
+	return len(proof.leafHash) > 0
 }
 
 // LeafHash returns nil if the namespace has leaves in the NMT. In case the

--- a/proof.go
+++ b/proof.go
@@ -66,7 +66,7 @@ func (proof Proof) Nodes() [][]byte {
 // IsOfAbsence returns true if this proof proves the absence of leaves of a
 // namespace in the tree.
 func (proof Proof) IsOfAbsence() bool {
-	return len(proof.leafHash) > 0
+	return len(proof.leafHash) > 0 && !(proof.start < 0) && (proof.end == proof.start+1)
 }
 
 // LeafHash returns nil if the namespace has leaves in the NMT. In case the
@@ -108,7 +108,7 @@ func NewAbsenceProof(proofStart, proofEnd int, proofNodes [][]byte, leafHash []b
 
 // IsEmptyProof checks whether the proof corresponds to an empty proof as defined in NMT specifications https://github.com/celestiaorg/nmt/blob/master/docs/spec/nmt.md.
 func (proof Proof) IsEmptyProof() bool {
-	return proof.start == proof.end && len(proof.nodes) == 0
+	return proof.start == proof.end && len(proof.nodes) == 0 && len(proof.leafHash) == 0
 }
 
 // VerifyNamespace verifies a whole namespace, i.e. 1) it verifies inclusion of

--- a/proof_test.go
+++ b/proof_test.go
@@ -642,41 +642,41 @@ func TestIsEmptyProof(t *testing.T) {
 		expected bool
 	}{
 		{
-			name: "valid absence proof",
+			name: "valid empty proof",
+			proof: Proof{
+				leafHash: nil,
+				nodes:    nil,
+				start:    1,
+				end:      1,
+			},
+			expected: true,
+		},
+		{
+			name: "invalid empty proof - start != end",
 			proof: Proof{
 				leafHash: nil,
 				nodes:    nil,
 				start:    0,
 				end:      1,
 			},
-			expected: true,
+			expected: false,
 		},
 		{
-			name: "invalid absence proof - start < 0",
+			name: "invalid empty proof - non-empty nodes",
 			proof: Proof{
 				leafHash: nil,
-				nodes:    nil,
-				start:    -1,
-				end:      0,
+				nodes:    [][]byte{{0x01}},
+				start:    1,
+				end:      1,
 			},
 			expected: false,
 		},
 		{
-			name: "invalid proof - end != start + 1",
+			name: "invalid absence proof - non-empty leafHash",
 			proof: Proof{
-				leafHash: nil,
+				leafHash: []byte{0x01},
 				nodes:    nil,
-				start:    0,
-				end:      2,
-			},
-			expected: false,
-		},
-		{
-			name: "invalid absence proof",
-			proof: Proof{
-				leafHash: nil,
-				nodes:    nil,
-				start:    0,
+				start:    1,
 				end:      1,
 			},
 			expected: false,
@@ -686,9 +686,8 @@ func TestIsEmptyProof(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			result := test.proof.IsEmptyProof()
-			if result != test.expected {
-				t.Errorf("unexpected result: expected %v but got %v", test.expected, result)
-			}
+			assert.Equal(t, test.expected, result)
+
 		})
 	}
 }

--- a/proof_test.go
+++ b/proof_test.go
@@ -583,62 +583,6 @@ func TestVerifyLeafHashes_False(t *testing.T) {
 	}
 }
 
-func TestIsOfAbsence(t *testing.T) {
-	tests := []struct {
-		name     string
-		proof    Proof
-		expected bool
-	}{
-		{
-			name: "valid absence proof",
-			proof: Proof{
-				leafHash: []byte{0x01, 0x02, 0x03},
-				nodes:    nil,
-				start:    0,
-				end:      1,
-			},
-			expected: true,
-		},
-		{
-			name: "invalid absence proof - start < 0",
-			proof: Proof{
-				leafHash: []byte{0x01, 0x02, 0x03},
-				nodes:    nil,
-				start:    -1,
-				end:      0,
-			},
-			expected: false,
-		},
-		{
-			name: "invalid proof - end != start + 1",
-			proof: Proof{
-				leafHash: []byte{0x01, 0x02, 0x03},
-				nodes:    nil,
-				start:    0,
-				end:      2,
-			},
-			expected: false,
-		},
-		{
-			name: "invalid absence proof",
-			proof: Proof{
-				leafHash: nil,
-				nodes:    nil,
-				start:    0,
-				end:      1,
-			},
-			expected: false,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			test.proof.IsOfAbsence()
-			// assert.Equal(t, test.expected, result)
-		})
-	}
-}
-
 func TestIsEmptyProof(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -691,6 +635,46 @@ func TestIsEmptyProof(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			result := test.proof.IsEmptyProof()
 			assert.Equal(t, test.expected, result)
+
+		})
+	}
+}
+
+// TestIsEmptyProofOverlapAbsenceProof ensures there is no overlap between empty proofs and absence proofs.
+func TestIsEmptyProofOverlapAbsenceProof(t *testing.T) {
+	tests := []struct {
+		name  string
+		proof Proof
+	}{
+		{
+			name: "valid empty proof",
+			proof: Proof{
+				leafHash: nil,
+				nodes:    nil,
+				start:    1,
+				end:      1,
+			},
+		},
+		{
+			name: "valid absence proof",
+			proof: Proof{
+				leafHash: []byte{0x01, 0x02, 0x03},
+				nodes:    nil,
+				start:    1,
+				end:      1,
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := test.proof.IsEmptyProof()
+			absenceResult := test.proof.IsOfAbsence()
+			if result {
+				assert.False(t, absenceResult)
+			}
+			if absenceResult {
+				assert.False(t, result)
+			}
 
 		})
 	}

--- a/proof_test.go
+++ b/proof_test.go
@@ -573,3 +573,117 @@ func TestVerifyLeafHashes_False(t *testing.T) {
 		})
 	}
 }
+
+func TestIsOfAbsence(t *testing.T) {
+	tests := []struct {
+		name     string
+		proof    Proof
+		expected bool
+	}{
+		{
+			name: "valid absence proof",
+			proof: Proof{
+				leafHash: []byte{0x01, 0x02, 0x03},
+				nodes:    nil,
+				start:    0,
+				end:      1,
+			},
+			expected: true,
+		},
+		{
+			name: "invalid absence proof - start < 0",
+			proof: Proof{
+				leafHash: []byte{0x01, 0x02, 0x03},
+				nodes:    nil,
+				start:    -1,
+				end:      0,
+			},
+			expected: false,
+		},
+		{
+			name: "invalid proof - end != start + 1",
+			proof: Proof{
+				leafHash: []byte{0x01, 0x02, 0x03},
+				nodes:    nil,
+				start:    0,
+				end:      2,
+			},
+			expected: false,
+		},
+		{
+			name: "invalid absence proof",
+			proof: Proof{
+				leafHash: nil,
+				nodes:    nil,
+				start:    0,
+				end:      1,
+			},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := test.proof.IsOfAbsence()
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func TestIsEmptyProof(t *testing.T) {
+	tests := []struct {
+		name     string
+		proof    Proof
+		expected bool
+	}{
+		{
+			name: "valid absence proof",
+			proof: Proof{
+				leafHash: nil,
+				nodes:    nil,
+				start:    0,
+				end:      1,
+			},
+			expected: true,
+		},
+		{
+			name: "invalid absence proof - start < 0",
+			proof: Proof{
+				leafHash: nil,
+				nodes:    nil,
+				start:    -1,
+				end:      0,
+			},
+			expected: false,
+		},
+		{
+			name: "invalid proof - end != start + 1",
+			proof: Proof{
+				leafHash: nil,
+				nodes:    nil,
+				start:    0,
+				end:      2,
+			},
+			expected: false,
+		},
+		{
+			name: "invalid absence proof",
+			proof: Proof{
+				leafHash: nil,
+				nodes:    nil,
+				start:    0,
+				end:      1,
+			},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := test.proof.IsEmptyProof()
+			if result != test.expected {
+				t.Errorf("unexpected result: expected %v but got %v", test.expected, result)
+			}
+		})
+	}
+}

--- a/proof_test.go
+++ b/proof_test.go
@@ -625,7 +625,6 @@ func TestIsEmptyProof(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			result := test.proof.IsEmptyProof()
 			assert.Equal(t, test.expected, result)
-
 		})
 	}
 }
@@ -665,7 +664,6 @@ func TestIsEmptyProofOverlapAbsenceProof(t *testing.T) {
 			if absenceResult {
 				assert.False(t, result)
 			}
-
 		})
 	}
 }


### PR DESCRIPTION
## Overview
Closes #181
The updates made by this PR will result in a breaking change, as empty proofs with a non-empty `leafHash` field will no longer be considered valid. This means that their verification through `VerifyNamespace` will fail.
Example:
```go
nIDSize := 1
tree := exampleNMT(nIDSize, 1, 2, 3, 4)
root, err := tree.Root()
require.NoError(t, err)
hasher := 
proof := Proof{
		start:    0,
		end:      0,
		nodes:    nil,
		leafHash: tree.leafHashes[0],
	}

res := proof.VerifyNamespace(tree.treeHasher.baseHasher, []byte{0}, [][]byte{}, root)
require.True(res) // this is false with the changes in this PR, however, previously, it was true
```

## Checklist


- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
