### PR TITLE
Fix grammatical error Update nmt-lib.md

### DIFF
--- a/docs/nmt-lib.md
+++ b/docs/nmt-lib.md
@@ -58,7 +58,7 @@ Note that the `IgnoreMaxNamespace` flag is Celestia-specific and is motivated by
 
 Data items are added to the tree using the `Push` method.
 Data items should be prefixed with namespaces of size set out for the NMT (i.e., `tree.NamespaceSize()`) and added in ascending order of their namespace IDs to avoid errors during the `Push` process.
-Non-compliance with either of these requirements cause `Push` to fail.
+Non-compliance with either of these requirements will cause `Push` to fail.
 
 ```go
 func (n *NamespacedMerkleTree) Push(namespacedData namespace.PrefixedData) error


### PR DESCRIPTION
**Description:**

Corrects a grammatical error in the NMT documentation. Specifically, the phrase:

```
Non-compliance with either of these requirements cause `Push` to fail.
```

has been corrected to:

```
Non-compliance with either of these requirements will cause `Push` to fail.
```

**Explanation of the fix:**

The word "cause" is incorrect in this context, as it doesn't match the subject of the sentence ("Non-compliance"). The correct form is "will cause," as it properly conveys the future outcome of the action described.

**Why this is important:**

While the error may seem minor, maintaining grammatical accuracy in documentation is crucial for clarity and professionalism. Ensuring correct phrasing helps readers understand the material better and reduces the risk of confusion, especially for developers who rely on clear instructions.
