### PR TITLE
test: empty root

### DIFF
--- a/hasher_test.go
+++ b/hasher_test.go
@@ -898,19 +898,30 @@ func TestComputeNsRange(t *testing.T) {
 	}
 }
 
-// TestEmptyRoot ensures that the empty root is always the same, under the same configuration, regardless of the state of the Hasher.
 func TestEmptyRoot(t *testing.T) {
-	nIDSzie := 1
-	ignoreMaxNS := true
+	t.Run("the empty root should match a hard-coded empty root", func(t *testing.T) {
+		nIDSzie := 1
+		ignoreMaxNS := true
 
-	hasher := NewNmtHasher(sha256.New(), namespace.IDSize(nIDSzie), ignoreMaxNS)
-	expectedEmptyRoot := hasher.EmptyRoot()
+		hasher := NewNmtHasher(sha256.New(), namespace.IDSize(nIDSzie), ignoreMaxNS)
+		got := hasher.EmptyRoot()
+		want := []byte{0x0, 0x0, 0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14, 0x9a, 0xfb, 0xf4, 0xc8, 0x99, 0x6f, 0xb9, 0x24, 0x27, 0xae, 0x41, 0xe4, 0x64, 0x9b, 0x93, 0x4c, 0xa4, 0x95, 0x99, 0x1b, 0x78, 0x52, 0xb8, 0x55}
+		assert.Equal(t, want, got)
+	})
 
-	// perform some operation with the hasher
-	_, err := hasher.HashNode(createByteSlice(hasher.Size(), 1), createByteSlice(hasher.Size(), 1))
-	assert.NoError(t, err)
-	gotEmptyRoot := hasher.EmptyRoot()
+	t.Run("empty root should return the same root even if the hasher is modified", func(t *testing.T) {
+		nIDSzie := 1
+		ignoreMaxNS := true
 
-	// the empty root should be the same before and after the operation
-	assert.True(t, bytes.Equal(gotEmptyRoot, expectedEmptyRoot))
+		hasher := NewNmtHasher(sha256.New(), namespace.IDSize(nIDSzie), ignoreMaxNS)
+		want := hasher.EmptyRoot()
+
+		// perform some operation with the hasher
+		_, err := hasher.HashNode(createByteSlice(hasher.Size(), 1), createByteSlice(hasher.Size(), 1))
+		assert.NoError(t, err)
+		got := hasher.EmptyRoot()
+
+		// the empty root should be the same before and after the operation
+		assert.Equal(t, want, got)
+	})
 }


### PR DESCRIPTION
Motivation: I wanted a unit test to confirm https://github.com/celestiaorg/nmt/pull/287 doesn't change the empty root

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Improved test case organization for empty root hashing
	- Added sub-tests to enhance test clarity and maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->