### PR TITLE
refactor: small clenaups in helper funcs

### DIFF
--- a/hasher.go
+++ b/hasher.go
@@ -313,20 +313,6 @@ func (n *NmtHasher) HashNode(left, right []byte) ([]byte, error) {
 	return h.Sum(res), nil
 }
 
-func max(ns []byte, ns2 []byte) []byte {
-	if bytes.Compare(ns, ns2) >= 0 {
-		return ns
-	}
-	return ns2
-}
-
-func min(ns []byte, ns2 []byte) []byte {
-	if bytes.Compare(ns, ns2) <= 0 {
-		return ns
-	}
-	return ns2
-}
-
 // computeNsRange computes the namespace range of the parent node based on the namespace ranges of its left and right children.
 func computeNsRange(leftMinNs, leftMaxNs, rightMinNs, rightMaxNs []byte, ignoreMaxNs bool, precomputedMaxNs namespace.ID) (minNs []byte, maxNs []byte) {
 	minNs = leftMinNs

--- a/hasher_test.go
+++ b/hasher_test.go
@@ -749,7 +749,7 @@ func TestMax(t *testing.T) {
 
 	for _, ts := range tt {
 		t.Run(ts.name, func(t *testing.T) {
-			maxResult := max(ts.ns, ts.ns2)
+			maxResult := maxNs(ts.ns, ts.ns2)
 			assert.Equal(t, ts.expected, maxResult)
 		})
 	}
@@ -784,7 +784,7 @@ func TestMin(t *testing.T) {
 
 	for _, ts := range tt {
 		t.Run(ts.name, func(t *testing.T) {
-			minResult := min(ts.ns, ts.ns2)
+			minResult := minNs(ts.ns, ts.ns2)
 			assert.Equal(t, ts.expected, minResult)
 		})
 	}
@@ -925,4 +925,18 @@ func TestEmptyRoot(t *testing.T) {
 		// the empty root should be the same before and after the operation
 		assert.Equal(t, want, got)
 	})
+}
+
+func maxNs(ns []byte, ns2 []byte) []byte {
+	if bytes.Compare(ns, ns2) >= 0 {
+		return ns
+	}
+	return ns2
+}
+
+func minNs(ns []byte, ns2 []byte) []byte {
+	if bytes.Compare(ns, ns2) <= 0 {
+		return ns
+	}
+	return ns2
 }

--- a/nmt_test.go
+++ b/nmt_test.go
@@ -878,9 +878,7 @@ func exampleNMT2(nidSize int, ignoreMaxNamespace bool, leavesNIDs ...byte) *Name
 }
 
 func swap(slice [][]byte, i int, j int) {
-	temp := slice[i]
-	slice[i] = slice[j]
-	slice[j] = temp
+	slice[i], slice[j] = slice[j], slice[i]
 }
 
 // Test_buildRangeProof_Err tests that buildRangeProof returns an error when the underlying tree has an invalid state e.g., leaves are not ordered by namespace ID or a leaf hash is corrupted.

--- a/proof.go
+++ b/proof.go
@@ -632,7 +632,7 @@ func ToLeafRanges(proofStart, proofEnd, subtreeWidth int) ([]LeafRange, error) {
 // Note: This method is Celestia specific.
 func nextLeafRange(currentStart, currentEnd, subtreeWidth int) (LeafRange, error) {
 	currentLeafRange := currentEnd - currentStart
-	minimum := minInt(currentLeafRange, subtreeWidth)
+	minimum := min(currentLeafRange, subtreeWidth)
 	uMinimum, err := safeIntToUint(minimum)
 	if err != nil {
 		return LeafRange{}, fmt.Errorf("failed to convert subtree root range to Uint %w", err)
@@ -712,11 +712,4 @@ func safeIntToUint(val int) (uint, error) {
 		return 0, fmt.Errorf("cannot convert a negative int %d to uint", val)
 	}
 	return uint(val), nil
-}
-
-func minInt(val1, val2 int) int {
-	if val1 > val2 {
-		return val2
-	}
-	return val1
 }

--- a/proof_test.go
+++ b/proof_test.go
@@ -514,9 +514,7 @@ func TestVerifyNamespace_False(t *testing.T) {
 	require.True(t, absenceProof9_2.IsOfAbsence())
 
 	// swap leafHashes of the absence proofs
-	buffer := absenceProof9_2.leafHash
-	absenceProof9_2.leafHash = absenceProof9_1.leafHash
-	absenceProof9_1.leafHash = buffer
+	absenceProof9_2.leafHash, absenceProof9_1.leafHash = absenceProof9_1.leafHash, absenceProof9_2.leafHash
 
 	hasher := sha256.New()
 
@@ -1489,7 +1487,7 @@ func TestMinInt(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("val1=%d, val2=%d", tt.val1, tt.val2), func(t *testing.T) {
-			result := minInt(tt.val1, tt.val2)
+			result := min(tt.val1, tt.val2)
 			if result != tt.expected {
 				t.Errorf("expected %d, got %d", tt.expected, result)
 			}

--- a/subrootpaths.go
+++ b/subrootpaths.go
@@ -16,7 +16,7 @@ var (
 // this is just a quick function to return that representation as a list of ints
 func subdivide(idxStart uint, width uint) []int {
 	var path []int
-	pathlen := int(bits.Len(width) - 1)
+	pathlen := bits.Len(width) - 1
 	for i := pathlen - 1; i >= 0; i-- {
 		if (idxStart & (1 << i)) == 0 {
 			path = append(path, 0)


### PR DESCRIPTION
Micro PR that I did before and forget to push. Use `min` and `max` builtin funcs instead of own implementations. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

These updates focus on internal code quality improvements that enhance maintainability and clarity without changing user-visible functionality:

- **Refactor**
  - Streamlined internal logic by removing redundant comparison functions and adopting more concise coding patterns.
- **Tests**
  - Updated test routines to reflect improved naming conventions and ensure consistency.
- **Chores**
  - Simplified numerical operations and removed unnecessary type conversions for more robust code maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->