### PR TITLE
perf: use global prefix slices to avoid allocations

### DIFF
--- a/hasher.go
+++ b/hasher.go
@@ -14,6 +14,11 @@ const (
 	NodePrefix = 1
 )
 
+var (
+	leafPrefixSlice = []byte{LeafPrefix}
+	nodePrefixSlice = []byte{NodePrefix}
+)
+
 var _ hash.Hash = (*NmtHasher)(nil)
 
 var (
@@ -190,7 +195,7 @@ func (n *NmtHasher) HashLeaf(ndata []byte) ([]byte, error) {
 	minMaxNIDs = append(minMaxNIDs, nID...) // nID
 	minMaxNIDs = append(minMaxNIDs, nID...) // nID || nID
 
-	h.Write([]byte{LeafPrefix})
+	h.Write(leafPrefixSlice)
 	h.Write(ndata)
 
 	// compute h(LeafPrefix || ndata) and append it to the minMaxNIDs
@@ -307,7 +312,7 @@ func (n *NmtHasher) HashNode(left, right []byte) ([]byte, error) {
 	res = append(res, minNs...)
 	res = append(res, maxNs...)
 
-	h.Write([]byte{NodePrefix})
+	h.Write(nodePrefixSlice)
 	h.Write(left)
 	h.Write(right)
 	return h.Sum(res), nil


### PR DESCRIPTION
## Overview

This is a very low-hanging-fruit optimization that significantly (by over 24%) reduces number of allocations. Before the change, every time node/leaf prefix is used for hashing, small slice was dynamically allocated just to pass single byte. Keeping those slices as global values ensures they are allocated exactly once.

Benchmark results:
```
$ go-perftuner bstat before.txt after.txt
name                      old time/op    new time/op    delta
ComputeRoot/64-leaves-8      114µs ± 2%     114µs ± 1%        ~  (p=0.841 n=5+5)
ComputeRoot/128-leaves-8     226µs ± 1%     226µs ± 0%        ~  (p=0.730 n=5+4)
ComputeRoot/256-leaves-8     455µs ± 2%     452µs ± 2%        ~  (p=1.000 n=5+5)
ComputeRoot/20k-leaves-8    48.8ms ± 1%    48.4ms ± 2%        ~  (p=0.151 n=5+5)

name                      old alloc/op   new alloc/op   delta
ComputeRoot/64-leaves-8     31.0kB ± 0%    30.4kB ± 0%   -1.86%  (p=0.008 n=5+5)
ComputeRoot/128-leaves-8    55.4kB ± 0%    54.3kB ± 0%   -2.08%  (p=0.008 n=5+5)
ComputeRoot/256-leaves-8     117kB ± 0%     114kB ± 0%   -1.97%  (p=0.000 n=5+4)
ComputeRoot/20k-leaves-8    12.4MB ± 0%    12.2MB ± 0%   -1.46%  (p=0.008 n=5+5)

name                      old allocs/op  new allocs/op  delta
ComputeRoot/64-leaves-8        529 ± 0%       402 ± 0%  -24.01%  (p=0.008 n=5+5)
ComputeRoot/128-leaves-8     1.04k ± 0%     0.79k ± 0%  -24.45%  (p=0.008 n=5+5)
ComputeRoot/256-leaves-8     2.07k ± 0%     1.56k ± 0%  -24.67%  (p=0.008 n=5+5)
ComputeRoot/20k-leaves-8      160k ± 0%      120k ± 0%  -24.97%  (p=0.008 n=5+5)
```
