### PR TITLE
perf: avoid redundant slice allocation in leafHash assignment

### DIFF
--- a/nmt.go
+++ b/nmt.go
@@ -544,8 +544,7 @@ func (n *NamespacedMerkleTree) computeRoot(start, end int) ([]byte, error) {
 		n.visit(rootHash)
 		return rootHash, nil
 	case 1:
-		leafHash := make([]byte, len(n.leafHashes[start]))
-		copy(leafHash, n.leafHashes[start])
+		leafHash := n.leafHashes[start]
 		n.visit(leafHash, n.leaves[start])
 		return leafHash, nil
 	default:


### PR DESCRIPTION
## Overview
To reduce number of allocations, we can directly return precomputed leafs (without copying them).

## Benchmark results
```
$ go-perftuner benchstat before.txt after.txt
name                       old time/op    new time/op    delta
ComputeRoot/64-leaves-16      115µs ± 1%     112µs ± 0%   -2.80%  (p=0.008 n=5+5)
ComputeRoot/128-leaves-16     230µs ± 5%     223µs ± 1%        ~  (p=0.016 n=5+5)
ComputeRoot/256-leaves-16     456µs ± 1%     446µs ± 1%        ~  (p=0.008 n=5+5)
ComputeRoot/20k-leaves-16    49.7ms ± 1%    48.5ms ± 3%        ~  (p=0.095 n=5+5)

name                       old alloc/op   new alloc/op   delta
ComputeRoot/64-leaves-16     30.4kB ± 0%    27.4kB ± 0%  -10.09%  (p=0.008 n=5+5)
ComputeRoot/128-leaves-16    54.3kB ± 0%    48.1kB ± 0%  -11.32%  (p=0.008 n=5+5)
ComputeRoot/256-leaves-16     114kB ± 0%     102kB ± 0%  -10.73%  (p=0.008 n=5+5)
ComputeRoot/20k-leaves-16    12.2MB ± 0%    11.2MB ± 0%   -7.89%  (p=0.008 n=5+5)

name                       old allocs/op  new allocs/op  delta
ComputeRoot/64-leaves-16        402 ± 0%       338 ± 0%  -15.92%  (p=0.008 n=5+5)
ComputeRoot/128-leaves-16       788 ± 0%       660 ± 0%  -16.24%  (p=0.008 n=5+5)
ComputeRoot/256-leaves-16     1.56k ± 0%     1.30k ± 0%  -16.41%  (p=0.008 n=5+5)
ComputeRoot/20k-leaves-16      120k ± 0%      100k ± 0%  -16.64%  (p=0.008 n=5+5)
```