### PR TITLE
ci: remove dependency label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,8 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
-    labels:
-      - dependencies
   - package-ecosystem: gomod
     directory: "/"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
-    labels:
-      - dependencies


### PR DESCRIPTION
Motivation: https://github.com/celestiaorg/nmt/pull/302#issuecomment-3255676292

idk who removed the dependency label from this repo but IMO it is already clear that dependabot PRs are to update dependencies so the label doesn't add any value.