### PR TITLE
perf: reuse buffer for hashes (root calculation and leaves push)

### DIFF
--- a/hasher.go
+++ b/hasher.go
@@ -58,6 +58,7 @@ type NmtHasher struct { //nolint:revive
 	// "HashNode".
 	ignoreMaxNs      bool
 	precomputedMaxNs namespace.ID
+	buffer           *byteBuffer
 
 	tp   byte   // keeps type of NMT node to be hashed
 	data []byte // written data of the NMT node
@@ -188,10 +189,9 @@ func (n *NmtHasher) HashLeaf(ndata []byte) ([]byte, error) {
 	if err := n.ValidateLeaf(ndata); err != nil {
 		return nil, err
 	}
-
 	nID := ndata[:n.NamespaceLen]
 	resLen := int(2*n.NamespaceLen) + n.baseHasher.Size()
-	minMaxNIDs := make([]byte, 0, resLen)
+	minMaxNIDs := n.getBytes(resLen)
 	minMaxNIDs = append(minMaxNIDs, nID...) // nID
 	minMaxNIDs = append(minMaxNIDs, nID...) // nID || nID
 
@@ -307,8 +307,8 @@ func (n *NmtHasher) HashNode(left, right []byte) ([]byte, error) {
 
 	// compute the namespace range of the parent node
 	minNs, maxNs := computeNsRange(lRange.Min, lRange.Max, rRange.Min, rRange.Max, n.ignoreMaxNs, n.precomputedMaxNs)
-
-	res := make([]byte, 0, len(minNs)+len(maxNs)+h.Size())
+	totalLen := len(minNs) + len(maxNs) + h.Size()
+	res := n.getBytes(totalLen)
 	res = append(res, minNs...)
 	res = append(res, maxNs...)
 
@@ -316,6 +316,23 @@ func (n *NmtHasher) HashNode(left, right []byte) ([]byte, error) {
 	h.Write(left)
 	h.Write(right)
 	return h.Sum(res), nil
+}
+
+func (n *NmtHasher) initBuffer() {
+	n.buffer = newBuffer()
+}
+
+func (n *NmtHasher) resetBuffer() {
+	if n.buffer != nil {
+		n.buffer.reset()
+	}
+}
+
+func (n *NmtHasher) getBytes(size int) []byte {
+	if n.buffer != nil {
+		return n.buffer.get(size)
+	}
+	return make([]byte, 0, size)
 }
 
 // computeNsRange computes the namespace range of the parent node based on the namespace ranges of its left and right children.
@@ -326,4 +343,42 @@ func computeNsRange(leftMinNs, leftMaxNs, rightMinNs, rightMaxNs []byte, ignoreM
 		maxNs = leftMaxNs
 	}
 	return minNs, maxNs
+}
+
+// byteBuffer is a simple non-thread-safe buffer of byte slices
+type byteBuffer struct {
+	free      [][]byte // available buffers
+	allocated [][]byte // buffers currently in use
+}
+
+// newBuffer creates a new byte buffer
+func newBuffer() *byteBuffer {
+	return &byteBuffer{}
+}
+
+// get retrieves a byte slice from the buffer
+// If no free buffers available, allocates a new one
+func (p *byteBuffer) get(size int) []byte {
+	var b []byte
+
+	if len(p.free) > 0 {
+		lastIdx := len(p.free) - 1
+		b = p.free[lastIdx]
+		p.free = p.free[:lastIdx]
+
+		if cap(b) < size {
+			b = make([]byte, size)
+		}
+	} else {
+		b = make([]byte, size)
+	}
+	b = b[:0]
+	p.allocated = append(p.allocated, b)
+	return b
+}
+
+// reset moves all allocated buffers back to free buffer
+func (p *byteBuffer) reset() {
+	p.free = append(p.free, p.allocated...)
+	p.allocated = p.allocated[:0]
 }

--- a/hasher_test.go
+++ b/hasher_test.go
@@ -8,10 +8,9 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/celestiaorg/nmt/namespace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/celestiaorg/nmt/namespace"
 )
 
 const (

--- a/hasher_test.go
+++ b/hasher_test.go
@@ -8,9 +8,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/celestiaorg/nmt/namespace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/celestiaorg/nmt/namespace"
 )
 
 const (

--- a/nmt.go
+++ b/nmt.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"hash"
 	"math/bits"
+	"unsafe"
 
 	"github.com/celestiaorg/nmt/namespace"
 )
@@ -39,6 +40,7 @@ type Options struct {
 	// in the "Hasher.
 	IgnoreMaxNamespace bool
 	NodeVisitor        NodeVisitorFn
+	ReuseBuffer        bool
 	Hasher             Hasher
 }
 
@@ -90,9 +92,16 @@ func CustomHasher(h Hasher) Option {
 	}
 }
 
+func ReuseBuffer(reuse bool) Option {
+	return func(o *Options) {
+		o.ReuseBuffer = reuse
+	}
+}
+
 type NamespacedMerkleTree struct {
-	treeHasher Hasher
-	visit      NodeVisitorFn
+	reuseBuffer bool
+	treeHasher  Hasher
+	visit       NodeVisitorFn
 
 	// just cache stuff until we pass in a store and keep all nodes in there
 	// currently, only leaves and leafHashes are stored:
@@ -121,6 +130,11 @@ type NamespacedMerkleTree struct {
 	rawRoot []byte
 }
 
+type memoryReuseHasher interface {
+	initBuffer()
+	resetBuffer()
+}
+
 // New initializes a namespaced Merkle tree using the given base hash function
 // and for the given namespace size (number of bytes). If the namespace size is
 // 0 this corresponds to a regular non-namespaced Merkle tree.
@@ -130,7 +144,6 @@ func New(h hash.Hash, setters ...Option) *NamespacedMerkleTree {
 		InitialCapacity:    DefaultCapacity,
 		NamespaceIDSize:    DefaultNamespaceIDLen,
 		IgnoreMaxNamespace: true,
-		NodeVisitor:        noOp,
 	}
 
 	for _, setter := range setters {
@@ -145,10 +158,16 @@ func New(h hash.Hash, setters ...Option) *NamespacedMerkleTree {
 	for _, setter := range setters {
 		setter(opts)
 	}
+	if opts.ReuseBuffer {
+		if reuseHasher, ok := opts.Hasher.(memoryReuseHasher); ok {
+			reuseHasher.initBuffer()
+		}
+	}
 
 	return &NamespacedMerkleTree{
 		treeHasher:      opts.Hasher,
 		visit:           opts.NodeVisitor,
+		reuseBuffer:     opts.ReuseBuffer,
 		leaves:          make([][]byte, 0, opts.InitialCapacity),
 		leafHashes:      make([][]byte, 0, opts.InitialCapacity),
 		namespaceRanges: make(map[string]LeafRange),
@@ -163,6 +182,18 @@ func New(h hash.Hash, setters ...Option) *NamespacedMerkleTree {
 // If the supplied index is invalid i.e., if index < 0 or index > n.Size(), then Prove returns an ErrInvalidRange error. Any other errors rather than this are irrecoverable and indicate an illegal state of the tree (n).
 func (n *NamespacedMerkleTree) Prove(index int) (Proof, error) {
 	return n.ProveRange(index, index+1)
+}
+
+func (n *NamespacedMerkleTree) Reset() {
+	n.leaves = n.leaves[:0]
+	n.leafHashes = n.leafHashes[:0]
+	n.rawRoot = nil
+	n.namespaceRanges = map[string]LeafRange{} // Fresh map each time
+	n.minNID = bytes.Repeat([]byte{0xFF}, int(n.treeHasher.NamespaceSize()))
+	n.maxNID = bytes.Repeat([]byte{0x00}, int(n.treeHasher.NamespaceSize()))
+	if reuseHasher, ok := n.treeHasher.(memoryReuseHasher); ok {
+		reuseHasher.resetBuffer()
+	}
 }
 
 // ProveRange returns a Merkle inclusion proof for a specified range of leaves,
@@ -483,7 +514,13 @@ func (n *NamespacedMerkleTree) Root() ([]byte, error) {
 		if err != nil {
 			return nil, err // this should never happen since leaves are validated in the Push method
 		}
-		n.rawRoot = res
+		if n.reuseBuffer {
+			// we will reuse root's bytes, so we copy
+			n.rawRoot = make([]byte, len(res))
+			copy(n.rawRoot, res)
+		} else {
+			n.rawRoot = res
+		}
 	}
 	return n.rawRoot, nil
 }
@@ -541,11 +578,15 @@ func (n *NamespacedMerkleTree) computeRoot(start, end int) ([]byte, error) {
 	switch end - start {
 	case 0:
 		rootHash := n.treeHasher.EmptyRoot()
-		n.visit(rootHash)
+		if n.visit != nil {
+			n.visit(rootHash)
+		}
 		return rootHash, nil
 	case 1:
 		leafHash := n.leafHashes[start]
-		n.visit(leafHash, n.leaves[start])
+		if n.visit != nil {
+			n.visit(leafHash, n.leaves[start])
+		}
 		return leafHash, nil
 	default:
 		k := getSplitPoint(end - start)
@@ -561,7 +602,9 @@ func (n *NamespacedMerkleTree) computeRoot(start, end int) ([]byte, error) {
 		if err != nil { // this error should never happen since leaves are added through the Push method, during which leaves formats are validated and their namespace IDs are checked to be sequential.
 			return nil, fmt.Errorf("failed to compute subtree root [%d, %d): %w", left, right, err)
 		}
-		n.visit(hash, left, right)
+		if n.visit != nil {
+			n.visit(hash, left, right)
+		}
 		return hash, nil
 	}
 }
@@ -586,7 +629,13 @@ func (n *NamespacedMerkleTree) updateNamespaceRanges() {
 	if n.Size() > 0 {
 		lastIndex := n.Size() - 1
 		lastPushed := n.leaves[lastIndex]
-		lastNsStr := string(lastPushed[:n.treeHasher.NamespaceSize()])
+		var lastNsStr string
+		if n.reuseBuffer {
+			// this should be safe to do in all cases, but to be on the safe side using only on a specific option
+			lastNsStr = unsafeBytesToString(lastPushed[:n.treeHasher.NamespaceSize()])
+		} else {
+			lastNsStr = string(lastPushed[:n.treeHasher.NamespaceSize()])
+		}
 		lastRange, found := n.namespaceRanges[lastNsStr]
 		if !found {
 			n.namespaceRanges[lastNsStr] = LeafRange{
@@ -694,4 +743,11 @@ func MaxNamespace(hash []byte, size namespace.IDSize) []byte {
 // Size returns the number of leaves in the tree.
 func (n *NamespacedMerkleTree) Size() int {
 	return len(n.leaves)
+}
+
+func unsafeBytesToString(b []byte) string {
+	if len(b) == 0 {
+		return ""
+	}
+	return unsafe.String(&b[0], len(b))
 }

--- a/nmt.go
+++ b/nmt.go
@@ -94,6 +94,8 @@ func CustomHasher(h Hasher) Option {
 
 // ReuseBuffers option will use default's hasher buffer reuse capabilities
 // and reuse part of leaves' buffers to check if the namespace exists in a map.
+// Bear in mind that when we want to reuse the NMT for the next batch of data (e.g. new square row),
+// we need to call `Reset` on the tree.
 func ReuseBuffers(reuse bool) Option {
 	return func(o *Options) {
 		o.ReuseBuffers = reuse
@@ -189,6 +191,9 @@ func (n *NamespacedMerkleTree) Prove(index int) (Proof, error) {
 	return n.ProveRange(index, index+1)
 }
 
+// Reset resets the tree data for subsequent reuse, also resets the allocated buffers for leafHashes,
+// so they won't be allocated again. We don't reuse buffers for `leaves`,
+// because the data is provided externally and not managed by the NMT.
 func (n *NamespacedMerkleTree) Reset() {
 	n.leaves = n.leaves[:0]
 	n.leafHashes = n.leafHashes[:0]


### PR DESCRIPTION
## Overview

**This PR introduces an option `ReuseBuffers`** which will enable the `NamespacedMerkleTree` and the `NmtHasher` to reuse the buffers. The pipeline looks like this (if the option is enabled):
- on first run we use the hasher normally, but underneath it tracks all the slices allocated for hashes
- after we call `Reset` on nmt, the buffers are reset and the previously allocated slices are available for reuse
- the next time the allocations will not happen.

This gives us roughly 15% performance gains when used repeatedly, results in 3x less memory used and 95% less allocations.

**If the option is not enabled, the tree functionality is not affected.**

## Benchmarks

```
cpu: Apple M1 Max
BenchmarkNMTReuseVsNoReuse
BenchmarkNMTReuseVsNoReuse/128-leaves-Root-NoReuse
BenchmarkNMTReuseVsNoReuse/128-leaves-Root-NoReuse-10         	   16126	     73970 ns/op	   54377 B/op	     405 allocs/op
BenchmarkNMTReuseVsNoReuse/128-leaves-Root-ReuseTree
BenchmarkNMTReuseVsNoReuse/128-leaves-Root-ReuseTree-10       	   17980	     67043 ns/op	   19035 B/op	      16 allocs/op
BenchmarkNMTReuseVsNoReuse/256-leaves-Root-NoReuse
BenchmarkNMTReuseVsNoReuse/256-leaves-Root-NoReuse-10         	    8052	    156591 ns/op	  114570 B/op	     793 allocs/op
BenchmarkNMTReuseVsNoReuse/256-leaves-Root-ReuseTree
BenchmarkNMTReuseVsNoReuse/256-leaves-Root-ReuseTree-10       	    9129	    133909 ns/op	   37509 B/op	      18 allocs/op
BenchmarkNMTReuseVsNoReuse/512-leaves-Root-NoReuse
BenchmarkNMTReuseVsNoReuse/512-leaves-Root-NoReuse-10         	    3771	    316411 ns/op	  240045 B/op	    1565 allocs/op
BenchmarkNMTReuseVsNoReuse/512-leaves-Root-ReuseTree
BenchmarkNMTReuseVsNoReuse/512-leaves-Root-ReuseTree-10       	    4594	    264981 ns/op	   78535 B/op	      20 allocs/op
BenchmarkNMTReuseVsNoReuse/1024-leaves-Root-NoReuse
BenchmarkNMTReuseVsNoReuse/1024-leaves-Root-NoReuse-10        	    1806	    660065 ns/op	  545798 B/op	    3110 allocs/op
BenchmarkNMTReuseVsNoReuse/1024-leaves-Root-ReuseTree
BenchmarkNMTReuseVsNoReuse/1024-leaves-Root-ReuseTree-10      	    2260	    540510 ns/op	  160695 B/op	      26 allocs/op
BenchmarkNMTReuseVsNoReuse/2048-leaves-Root-NoReuse
BenchmarkNMTReuseVsNoReuse/2048-leaves-Root-NoReuse-10        	     877	   1376183 ns/op	 1037494 B/op	    6194 allocs/op
BenchmarkNMTReuseVsNoReuse/2048-leaves-Root-ReuseTree
BenchmarkNMTReuseVsNoReuse/2048-leaves-Root-ReuseTree-10      	    1076	   1084137 ns/op	  325373 B/op	      38 allocs/op
``` 