### PR TITLE
fix: reject truncated proofs in validateCompleteness (GHSA-r9fq-g486-v8pg)

### DIFF
--- a/proof.go
+++ b/proof.go
@@ -316,6 +316,16 @@ func (proof Proof) validateCompleteness(nth *NmtHasher, nID namespace.ID) error 
 		nodes = nodes[1:]
 		leafIndex += uint64(subtreeSize)
 	}
+	// If the nodes slice was exhausted before the left traversal reached
+	// proof.Start(), the proof is truncated. Without this guard, rightSubtrees
+	// below would be empty and the right-side namespace check would be
+	// silently skipped — see GHSA-r9fq-g486-v8pg.
+	if leafIndex != uint64(proof.Start()) {
+		return fmt.Errorf(
+			"proof nodes insufficient: left traversal reached leaf index %d, expected %d",
+			leafIndex, proof.Start(),
+		)
+	}
 	// rightSubtrees only contains the subtrees after r.End
 	rightSubtrees := nodes
 

--- a/proof.go
+++ b/proof.go
@@ -322,8 +322,8 @@ func (proof Proof) validateCompleteness(nth *NmtHasher, nID namespace.ID) error 
 	// silently skipped — see GHSA-r9fq-g486-v8pg.
 	if leafIndex != uint64(proof.Start()) {
 		return fmt.Errorf(
-			"proof nodes insufficient: left traversal reached leaf index %d, expected %d",
-			leafIndex, proof.Start(),
+			"%w: proof nodes insufficient: left traversal reached leaf index %d, expected %d",
+			ErrFailedCompletenessCheck, leafIndex, proof.Start(),
 		)
 	}
 	// rightSubtrees only contains the subtrees after r.End

--- a/proof_completeness_test.go
+++ b/proof_completeness_test.go
@@ -1,0 +1,96 @@
+package nmt
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	"github.com/celestiaorg/nmt/namespace"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateCompleteness_TruncatedProof_RejectsEmptyNodes ensures that a
+// proof whose nodes slice is empty (but whose start index is non-zero) is
+// rejected. Before the fix, the left-traversal loop exited immediately on
+// `len(nodes) > 0`, rightSubtrees became empty, and the function silently
+// returned nil even though no completeness check was actually performed.
+func TestValidateCompleteness_TruncatedProof_RejectsEmptyNodes(t *testing.T) {
+	nth := NewNmtHasher(sha256.New(), namespace.IDSize(1), false)
+	targetNID := namespace.ID{0x05}
+
+	// start=8 requires the left traversal to walk indices [0, 8). With an
+	// empty nodes slice, the loop cannot consume anything and leafIndex
+	// stays at 0, never reaching proof.Start()=8.
+	proof := Proof{
+		start: 8,
+		end:   9,
+		nodes: nil,
+	}
+
+	err := proof.validateCompleteness(nth, targetNID)
+	require.Error(t, err,
+		"validateCompleteness must reject a proof whose nodes are "+
+			"exhausted before the left traversal reaches proof.Start()")
+}
+
+// TestValidateCompleteness_TruncatedProof_RejectsInsufficientNodes is the
+// non-empty variant: the nodes slice has some entries but is still too short
+// to carry the left traversal to proof.Start().
+func TestValidateCompleteness_TruncatedProof_RejectsInsufficientNodes(t *testing.T) {
+	nth := NewNmtHasher(sha256.New(), namespace.IDSize(1), false)
+	targetNID := namespace.ID{0x05}
+
+	// A single well-formed NMT node whose namespace range is [0x01, 0x01]
+	// (strictly less than targetNID). As a leftSubtree this passes the
+	// left-side check; it's only in the slice so the left traversal
+	// consumes something before nodes are exhausted.
+	smallNID := []byte{0x01}
+	digest := sha256.Sum256([]byte("leftSubtreeNode"))
+	node := append(append([]byte{}, smallNID...), smallNID...)
+	node = append(node, digest[:]...)
+
+	// For start=12:
+	//   - iter 1: nextSubtreeSize(0, 12) = 8, consumes the only node,
+	//             leafIndex advances to 8, nodes becomes empty.
+	//   - iter 2: loop exits via len(nodes) > 0 == false,
+	//             leafIndex=8 != proof.Start()=12.
+	proof := Proof{
+		start: 12,
+		end:   13,
+		nodes: [][]byte{node},
+	}
+
+	err := proof.validateCompleteness(nth, targetNID)
+	require.Error(t, err,
+		"validateCompleteness must reject a proof whose nodes are "+
+			"exhausted partway through the left traversal "+
+			"(leafIndex stuck before proof.Start())")
+}
+
+// TestValidateCompleteness_RightSideCheck_StillRejectsSmallNamespace is a
+// control test: it confirms the right-side namespace check itself still
+// works and that the fix only rejects the truncated-proof case, not the
+// well-formed case where start==0 and a right subtree's namespace is
+// <= targetNID.
+func TestValidateCompleteness_RightSideCheck_StillRejectsSmallNamespace(t *testing.T) {
+	nth := NewNmtHasher(sha256.New(), namespace.IDSize(1), false)
+	targetNID := namespace.ID{0x05}
+
+	// Right subtree with min-namespace 0x01, which is <= targetNID 0x05,
+	// so the right-side check must reject it.
+	smallNID := []byte{0x01}
+	digest := sha256.Sum256([]byte("rightSubtreeNode"))
+	rightNode := append(append([]byte{}, smallNID...), smallNID...)
+	rightNode = append(rightNode, digest[:]...)
+
+	// start=0 means the left-traversal loop exits immediately with
+	// leafIndex == proof.Start() == 0, so the new insufficiency check
+	// does not trip. The sole node becomes a rightSubtree.
+	proof := Proof{
+		start: 0,
+		end:   1,
+		nodes: [][]byte{rightNode},
+	}
+
+	err := proof.validateCompleteness(nth, targetNID)
+	require.ErrorIs(t, err, ErrFailedCompletenessCheck)
+}

--- a/proof_completeness_test.go
+++ b/proof_completeness_test.go
@@ -27,7 +27,7 @@ func TestValidateCompleteness_TruncatedProof_RejectsEmptyNodes(t *testing.T) {
 	}
 
 	err := proof.validateCompleteness(nth, targetNID)
-	require.Error(t, err,
+	require.ErrorIs(t, err, ErrFailedCompletenessCheck,
 		"validateCompleteness must reject a proof whose nodes are "+
 			"exhausted before the left traversal reaches proof.Start()")
 }
@@ -60,7 +60,7 @@ func TestValidateCompleteness_TruncatedProof_RejectsInsufficientNodes(t *testing
 	}
 
 	err := proof.validateCompleteness(nth, targetNID)
-	require.Error(t, err,
+	require.ErrorIs(t, err, ErrFailedCompletenessCheck,
 		"validateCompleteness must reject a proof whose nodes are "+
 			"exhausted partway through the left traversal "+
 			"(leafIndex stuck before proof.Start())")


### PR DESCRIPTION
## Summary

Fixes a defense-in-depth gap in `validateCompleteness` reported in [GHSA-r9fq-g486-v8pg](https://github.com/celestiaorg/nmt/security/advisories/GHSA-r9fq-g486-v8pg).

The left-traversal loop in `validateCompleteness` exits when **either** `leafIndex == proof.Start()` **or** `len(nodes) == 0`. In the second case, `rightSubtrees` gets the (now empty) nodes slice, the right-side namespace-check loop iterates zero times, and the function silently returns `nil` — even though no completeness check actually ran.

Add an explicit post-loop guard that returns a wrapped `ErrFailedCompletenessCheck` so early node exhaustion fails loudly and is identifiable via `errors.Is`, matching the two existing sentinel returns in the same function.

## Impact

Narrow. The end-to-end `VerifyLeafHashes` / `ComputeRootWithBasicValidation` paths were still protected because `computeRoot` rejects truncated proofs (wrong root hash). The reporter's own PoC confirmed `VerifyNamespace` still returns `false`. But any future caller that split completeness checking from root verification would have been exposed, and the inner invariant was simply wrong — hence the fix.

## Tests

Three unit tests in `proof_completeness_test.go`, written **before** the fix to verify red/green:

- `TestValidateCompleteness_TruncatedProof_RejectsEmptyNodes` — `start=8`, empty `nodes`. Loop exits immediately; without the fix, returns nil.
- `TestValidateCompleteness_TruncatedProof_RejectsInsufficientNodes` — `start=12`, one node. Loop consumes it on the first iteration, advances `leafIndex` to 8, then exits because `nodes` is empty even though `leafIndex != 12`.
- `TestValidateCompleteness_RightSideCheck_StillRejectsSmallNamespace` — control: `start=0` with a right-subtree node whose namespace is `<=` the target. The existing right-side check still fires (returns `ErrFailedCompletenessCheck`), confirming the fix narrowly rejects truncation rather than breaking the normal path.

Both truncation tests assert identity via `require.ErrorIs(err, ErrFailedCompletenessCheck)`.

Verified red/green:
- Before the `proof.go` change: two new tests fail, control passes.
- After the fix: all three pass; full `go test ./...` suite green.

## Review follow-ups

- `fd647f5`: addressed `gemini-code-assist` review — wrap `ErrFailedCompletenessCheck` with `%w` in the new return and use `require.ErrorIs` in the tests for consistency with the other completeness-check returns in this function.

Addresses GHSA-r9fq-g486-v8pg.

## Test plan
- [x] `go test ./...` passes
- [x] Three new tests cover empty-nodes, insufficient-nodes, and control cases
- [x] Red/green verified manually
- [x] Error is `errors.Is`-identifiable as `ErrFailedCompletenessCheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)