### PR TITLE
ci: fix code scanning alerts

### DIFF
--- a/.github/workflows/buf-ci.yml
+++ b/.github/workflows/buf-ci.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-setup-action@v1
-      - uses: bufbuild/buf-breaking-action@v1
+      - uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1
+      - uses: bufbuild/buf-breaking-action@c57b3d842a5c3f3b454756ef65305a50a587c5ba # v1
         with:
           input: pb
           against: 'https://github.com/celestiaorg/nmt.git#branch=main,subdir=pb'
-      - uses: bufbuild/buf-lint-action@v1
+      - uses: bufbuild/buf-lint-action@06f9dd823d873146471cfaaf108a993fe00e5325 # v1
         with:
           input: pb

--- a/.github/workflows/buf-release.yml
+++ b/.github/workflows/buf-release.yml
@@ -3,17 +3,19 @@ on:
   push:
     tags:
       - "v*"
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-setup-action@v1
+      - uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           version: "1.44.0"
       # Push the protobuf definitions to the BSR
-      - uses: bufbuild/buf-push-action@v1
+      - uses: bufbuild/buf-push-action@a654ff18effe4641ebea4a4ce242c49800728459 # v1
         with:
           buf_token: ${{ secrets.BUF_TOKEN }}
       - name: "push the tag label to BSR"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
 
   build:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: read
 jobs:
   # Runs golangci-lint over the nmt repository
   # This workflow is run on every pull request and push to main
@@ -14,13 +16,13 @@ jobs:
     timeout-minutes: 4
     steps:
       - uses: actions/checkout@v4
-      - uses: technote-space/get-diff-action@v6
+      - uses: technote-space/get-diff-action@f27caffdd0fb9b13f4fc191c016bb4e0632844af # v6
         with:
           SUFFIX_FILTER: |
             .go
             .mod
             .sum
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6
         with:
           version: v1.61.0
           args: --timeout 10m
@@ -30,4 +32,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: celestiaorg/.github/.github/actions/markdown-lint@main
+      - uses: celestiaorg/.github/.github/actions/markdown-lint@157c2dcf3a5a7ebb9328d212c992e22d653a0ce2 # main


### PR DESCRIPTION
## Summary

- Add `permissions: contents: read` to `lint.yml`, `go.yml`, and `buf-release.yml` to follow least-privilege principle for `GITHUB_TOKEN`
- Pin all 3rd-party GitHub Actions to commit SHAs (with tag comments for readability) across all 4 workflow files
- Resolves all 12 open CodeQL code scanning alerts (#5, #6, #7, #9, #10, #11, #12, #20, #21, #22, #23, #24)

## Test plan
- [ ] CI workflows still pass (no functional changes, only permissions and ref pinning)
- [ ] Verify code scanning alerts move to "fixed" state after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)