### PR TITLE
ci: pin markdown-lint action to celestiaorg/.github v0.6.4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,4 +31,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: celestiaorg/.github/.github/actions/markdown-lint@v0.6.4
+      - uses: celestiaorg/.github/.github/actions/markdown-lint@9ee03305d3cc6cf520b7895436429aa853b58e70 # v0.6.4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,4 +31,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: celestiaorg/.github/.github/actions/markdown-lint@157c2dcf3a5a7ebb9328d212c992e22d653a0ce2 # main
+      - uses: celestiaorg/.github/.github/actions/markdown-lint@v0.6.4


### PR DESCRIPTION
## Summary

- Switch the `markdown-lint` job from tracking `celestiaorg/.github@main` by commit SHA to `v0.6.4`, pinned by commit SHA with a trailing `# v0.6.4` comment (matches the style of the other pinned actions in this workflow and satisfies the CodeQL "unpinned 3rd party Action" alert).
- Supersedes #320 — Dependabot will bump this by tag going forward (the SHA/comment pair lets it do so without reintroducing the alert).

## Test plan

- [ ] `lint / markdown-lint` workflow passes on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)