### PR TITLE
fix: bound proof span in VerifySubtreeRootInclusion before allocating ranges

### DIFF
--- a/proof.go
+++ b/proof.go
@@ -550,6 +550,34 @@ func (proof Proof) VerifySubtreeRootInclusion(nth *NmtHasher, subtreeRoots [][]b
 		}
 	}
 
+	// Bound the proof span before constructing the leaf ranges. ToLeafRanges
+	// allocates one LeafRange per (at most) subtreeWidth leaves of the span
+	// [proof.Start(), proof.End()), and proof.End() is attacker-controlled.
+	// Each provided subtree root can cover at most subtreeWidth leaves, so a
+	// proof whose span exceeds len(subtreeRoots)*subtreeWidth leaves can never
+	// satisfy the len(subtreeRoots) == len(ranges) check below. Reject such
+	// proofs here, before allocating, to avoid memory/CPU amplification from a
+	// large attacker-chosen span.
+	if subtreeWidth <= 0 {
+		return false, fmt.Errorf("subtree root width %d should be strictly positive", subtreeWidth)
+	}
+	if len(subtreeRoots) == 0 {
+		return false, fmt.Errorf("number of subtree roots cannot be zero")
+	}
+	// span is guaranteed >= 1 because proof.Start() < proof.End() was checked above.
+	span := proof.End() - proof.Start()
+	// Each leaf range covers at most subtreeWidth leaves, so ToLeafRanges will
+	// produce at least ceil(span/subtreeWidth) ranges. If that already exceeds
+	// len(subtreeRoots) the count check below would fail, so reject now. The
+	// comparison is written with division to avoid overflowing the int
+	// multiplication len(subtreeRoots)*subtreeWidth on attacker-chosen spans:
+	// ceil(span/subtreeWidth) > len(subtreeRoots).
+	quotient := span / subtreeWidth
+	remainder := span % subtreeWidth
+	if quotient > len(subtreeRoots) || (quotient == len(subtreeRoots) && remainder != 0) {
+		return false, fmt.Errorf("proof span %d exceeds the maximum number of leaves that %d subtree roots of width %d can cover", span, len(subtreeRoots), subtreeWidth)
+	}
+
 	// get the subtree roots leaf ranges
 	ranges, err := ToLeafRanges(proof.Start(), proof.End(), subtreeWidth)
 	if err != nil {

--- a/proof.go
+++ b/proof.go
@@ -550,28 +550,18 @@ func (proof Proof) VerifySubtreeRootInclusion(nth *NmtHasher, subtreeRoots [][]b
 		}
 	}
 
-	// Bound the proof span before constructing the leaf ranges. ToLeafRanges
-	// allocates one LeafRange per (at most) subtreeWidth leaves of the span
-	// [proof.Start(), proof.End()), and proof.End() is attacker-controlled.
-	// Each provided subtree root can cover at most subtreeWidth leaves, so a
-	// proof whose span exceeds len(subtreeRoots)*subtreeWidth leaves can never
-	// satisfy the len(subtreeRoots) == len(ranges) check below. Reject such
-	// proofs here, before allocating, to avoid memory/CPU amplification from a
-	// large attacker-chosen span.
+	// Bound the proof span before allocating leaf ranges.
+	// A wider span cannot be covered by the provided subtree roots.
 	if subtreeWidth <= 0 {
 		return false, fmt.Errorf("subtree root width %d should be strictly positive", subtreeWidth)
 	}
 	if len(subtreeRoots) == 0 {
 		return false, fmt.Errorf("number of subtree roots cannot be zero")
 	}
-	// span is guaranteed >= 1 because proof.Start() < proof.End() was checked above.
+	// proof.Start() < proof.End() was checked above, so span is at least 1.
 	span := proof.End() - proof.Start()
-	// Each leaf range covers at most subtreeWidth leaves, so ToLeafRanges will
-	// produce at least ceil(span/subtreeWidth) ranges. If that already exceeds
-	// len(subtreeRoots) the count check below would fail, so reject now. The
-	// comparison is written with division to avoid overflowing the int
-	// multiplication len(subtreeRoots)*subtreeWidth on attacker-chosen spans:
-	// ceil(span/subtreeWidth) > len(subtreeRoots).
+	// Reject when ceil(span/subtreeWidth) exceeds the available roots.
+	// Use division to avoid overflowing len(subtreeRoots)*subtreeWidth.
 	quotient := span / subtreeWidth
 	remainder := span % subtreeWidth
 	if quotient > len(subtreeRoots) || (quotient == len(subtreeRoots) && remainder != 0) {

--- a/proof_test.go
+++ b/proof_test.go
@@ -1866,6 +1866,45 @@ func TestVerifySubtreeRootInclusion_infiniteRecursion(t *testing.T) {
 	})
 }
 
+// TestVerifySubtreeRootInclusion_allocationBound ensures that an
+// attacker-controlled proof.End() cannot force VerifySubtreeRootInclusion to
+// allocate a huge slice of leaf ranges via ToLeafRanges before the cheap
+// len(subtreeRoots) count check. The verifier must reject a proof whose span
+// exceeds len(subtreeRoots)*subtreeWidth leaves up front, without allocating.
+func TestVerifySubtreeRootInclusion_allocationBound(t *testing.T) {
+	tree := exampleNMT(1, true, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+	root, err := tree.Root()
+	require.NoError(t, err)
+
+	hasher := tree.treeHasher.(*NmtHasher)
+
+	// A valid subtree root to keep subtreeRoots well-formed and non-empty.
+	subtreeRoot, err := tree.ComputeSubtreeRoot(0, 8)
+	require.NoError(t, err)
+	subtreeRoots := [][]byte{subtreeRoot}
+
+	// Attacker-sized span: a tiny proof message with a huge End and a small
+	// fixed width. Without the bound, ToLeafRanges would allocate roughly
+	// (1<<24)/64 = 262144 LeafRange entries before the count check rejects it.
+	const attackerEnd = 1 << 24
+	const subtreeWidth = 64
+	proof := NewInclusionProof(0, attackerEnd, nil, true)
+
+	ok, err := proof.VerifySubtreeRootInclusion(hasher, subtreeRoots, subtreeWidth, root)
+	require.False(t, ok)
+	require.Error(t, err)
+	// It must be the early span bound, not the post-ToLeafRanges count mismatch.
+	require.Contains(t, err.Error(), "exceeds the maximum number of leaves")
+	require.NotContains(t, err.Error(), "different than the number of the expected leaf ranges")
+
+	// Verify ToLeafRanges itself would have allocated the large slice, proving
+	// the verifier short-circuited before that expensive construction.
+	ranges, rErr := ToLeafRanges(0, attackerEnd, subtreeWidth)
+	require.NoError(t, rErr)
+	require.Equal(t, attackerEnd/subtreeWidth, len(ranges))
+	require.Greater(t, len(ranges), len(subtreeRoots))
+}
+
 func TestComputeRootWithBasicValidation(t *testing.T) {
 	tree := exampleNMT(1, true, 1, 2, 3, 3, 3, 4, 5, 6, 7, 8)
 	hasher := tree.treeHasher.(*NmtHasher)


### PR DESCRIPTION
`VerifySubtreeRootInclusion` calls `ToLeafRanges` (allocating O((End-Start)/subtreeWidth) ranges from an attacker-controlled `proof.End()`) before the cheap `len(subtreeRoots)` count check; this fix rejects proofs whose span exceeds `len(subtreeRoots)*subtreeWidth` before allocating.

This is strictly hardening with very limited production accessibility: the only in-tree caller (celestia-node's `CommitmentProof.Verify`) is not network-reachable and its width derivation already curbs allocation; the exposure is external consumers that verify untrusted proofs with a fixed small width, so fixing because it is cheap and correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)