### PR TITLE
ci: add proto-gen Makefile target, docs, and up-to-date check

### DIFF
--- a/.github/workflows/proto-gen.yml
+++ b/.github/workflows/proto-gen.yml
@@ -1,0 +1,40 @@
+name: proto-gen
+# This workflow verifies that the committed generated Protobuf files (*.pb.go)
+# match the files produced by regenerating from the definition files (*.proto).
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  proto-gen:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+
+      - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check generated Protobuf files match committed files
+        run: |
+          set -euo pipefail
+
+          make proto-gen
+
+          if ! git diff --stat --exit-code ; then
+            echo ">> ERROR:"
+            echo ">>"
+            echo ">> The committed generated Protobuf files don't match the files"
+            echo ">> generated from the Protobuf definition files."
+            echo ">> Run 'make proto-gen' and commit the changes."
+            echo ">>"
+            exit 1
+          fi

--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,11 @@ markdown-link-check:
 	@echo "--> Running markdown-link-check"
 	@find . -name \*.md -print0 | xargs -0 -n1 markdown-link-check
 .PHONY: markdown-link-check
+
+## proto-gen: Generate Go code from protobuf definition files. Requires protoc.
+proto-gen:
+	@echo "--> Installing protoc-gen-gogofaster"
+	@go install github.com/gogo/protobuf/protoc-gen-gogofaster
+	@echo "--> Generating Protobuf files"
+	@PATH="$$(go env GOPATH)/bin:$$PATH" protoc --gogofaster_out=paths=source_relative:. pb/proof.proto
+.PHONY: proto-gen

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,9 @@ markdown-link-check:
 
 ## proto-gen: Generate Go code from protobuf definition files. Requires protoc.
 proto-gen:
-	@echo "--> Installing protoc-gen-gogofaster"
+	@echo "--> Installing protoc-gen-gogofaster (version pinned by go.mod)"
 	@go install github.com/gogo/protobuf/protoc-gen-gogofaster
 	@echo "--> Generating Protobuf files"
-	@PATH="$$(go env GOPATH)/bin:$$PATH" protoc --gogofaster_out=paths=source_relative:. pb/proof.proto
+	@gobin="$$(go env GOBIN)"; [ -n "$$gobin" ] || gobin="$$(go env GOPATH)/bin"; \
+	protoc --plugin=protoc-gen-gogofaster="$$gobin/protoc-gen-gogofaster" --gogofaster_out=paths=source_relative:. pb/proof.proto
 .PHONY: proto-gen

--- a/README.md
+++ b/README.md
@@ -115,6 +115,16 @@ Markdown files must conform to [GitHub Flavored Markdown](https://github.github.
 - [markdownlint](https://github.com/DavidAnson/markdownlint)
 - [Markdown Table Prettifier](https://github.com/darkriszty/MarkdownTablePrettify-VSCodeExt)
 
+### Protobuf
+
+The [pb](./pb) package contains Protobuf definition files (`*.proto`) and the Go code (`*.pb.go`) generated from them. If you update a definition file, regenerate the Go code and commit both:
+
+```sh
+make proto-gen
+```
+
+This requires [protoc](https://protobuf.dev/installation/) to be installed. CI verifies that the committed generated code matches the definition files.
+
 ## Audits
 
 Date      | Auditor                                       | Report

--- a/pb/proof.pb.go
+++ b/pb/proof.pb.go
@@ -31,7 +31,7 @@ type Proof struct {
 	// Nodes hold the tree nodes necessary for the Merkle range proof.
 	Nodes [][]byte `protobuf:"bytes,3,rep,name=nodes,proto3" json:"nodes,omitempty"`
 	// leaf_hash contains the namespace.ID if NMT does not have it and
-	// it should be proven. LeafHash is necessary to prove the Absence Proof.
+	// it should be proven. leaf_hash is necessary to prove the Absence Proof.
 	// This field will be empty in case of Inclusion Proof.
 	LeafHash []byte `protobuf:"bytes,4,opt,name=leaf_hash,json=leafHash,proto3" json:"leaf_hash,omitempty"`
 	// The is_max_namespace_ignored flag influences the calculation of the


### PR DESCRIPTION
## Overview

- Add a `make proto-gen` target that regenerates `pb/*.pb.go` from the Protobuf definition files (plugin version pinned via go.mod, custom `GOBIN` supported), and document how to use it in the README. Closes #223
- Add a `proto-gen` CI workflow that fails if the committed generated code doesn't match what `make proto-gen` produces. Closes #224
- Regenerating surfaced a one-line comment drift in `pb/proof.pb.go` (the `.proto` comment was updated in #232 without regenerating) — fixed here, which is exactly the class of issue the new workflow catches.

Regarding #222: code coverage reporting was removed from this repo in f5b7a17 ("ci: remove code cov"), so there is no coverage workflow left to exclude generated files from. Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)