### PR TITLE
test: replace gofuzz with native Go fuzzing

### DIFF
--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -2,6 +2,7 @@ package nmt_test
 
 import (
 	"crypto/sha256"
+	"math/rand"
 	"reflect"
 	"sort"
 	"testing"
@@ -10,176 +11,151 @@ import (
 
 	"github.com/celestiaorg/nmt"
 	"github.com/celestiaorg/nmt/namespace"
-	fuzz "github.com/google/gofuzz"
 )
 
-func TestFuzzProveVerifyNameSpace(t *testing.T) {
+// FuzzProveVerifyNamespace builds trees from randomly generated namespaces and
+// leaf data, then checks that namespace proofs and inclusion proofs for every
+// namespace verify against the root. The fuzzed seed drives a deterministic
+// random generator so that every failure is reproducible from its corpus
+// entry. Run with: go test -fuzz=FuzzProveVerifyNamespace
+func FuzzProveVerifyNamespace(f *testing.F) {
 	if testing.Short() {
-		t.Skip("TestFuzzProveVerifyNameSpace skipped in short mode.")
+		f.Skip("FuzzProveVerifyNamespace skipped in short mode.")
 	}
-	var (
-		minNumberOfNamespaces = 4
-		maxNumberOfNamespaces = 64
-
-		minElementsPerNamespace = 0
-		maxElementsPerNamespace = 128
-
-		emptyNamespaceProbability = 0.15
-
-		testNsSizes = []testNamespaceSizes{size8, size16, size32}
-	)
-
-	for _, size := range testNsSizes {
-		nidDataMap, sortedKeys := makeRandDataAndSortedKeys(size, minNumberOfNamespaces, maxNumberOfNamespaces, minElementsPerNamespace, maxElementsPerNamespace, emptyNamespaceProbability)
-		t.Logf("Generated %v namespaces for size: %v ...", len(nidDataMap), size)
-		hash := sha256.New()
-		tree := nmt.New(hash, nmt.NamespaceIDSize(int(size)))
-
-		// push data in order:
-		for _, ns := range sortedKeys {
-			leafDataList := nidDataMap[ns]
-			for _, d := range leafDataList {
-				err := tree.Push(d)
-				if err != nil {
-					t.Fatalf("error on Push(): %v", err)
-				}
-			}
-		}
-
-		treeRoot, err := tree.Root()
-		require.NoError(t, err)
-		nonEmptyNsCount := 0
-		leafIdx := 0
-		for _, ns := range sortedKeys {
-			nid := namespace.ID(ns)
-			data := tree.Get(nid)
-			proof, err := tree.ProveNamespace(nid)
-			if err != nil {
-				t.Fatalf("error on ProveNamespace(%x): %v", ns, err)
-			}
-
-			if ok := proof.VerifyNamespace(hash, nid, data, treeRoot); !ok {
-				t.Fatalf("expected VerifyNamespace() == true")
-			}
-
-			// some sanity checks:
-			items := nidDataMap[ns]
-			if len(items) != len(data) {
-				t.Fatalf("returned number of items didn't match pushed number of items")
-			}
-			for i := 0; i < len(items); i++ {
-				if !reflect.DeepEqual(items[i], data[i]) {
-					t.Fatalf("returned data didn't math pushed data")
-				}
-				singleItemProof, err := tree.Prove(leafIdx)
-				if err != nil {
-					t.Fatalf("error on Prove(%v): %v", i, err)
-				}
-				if ok := singleItemProof.VerifyInclusion(hash, data[i][:size], [][]byte{data[i][size:]}, treeRoot); !ok {
-					t.Fatalf("expected VerifyInclusion() == true; data = %#v; proof = %#v", data[i], singleItemProof)
-				}
-				leafIdx++
-			}
-
-			isSingleLeaf := proof.End()-proof.Start() == 1
-			if len(data) == 0 && !isSingleLeaf &&
-				(proof.IsOfAbsence() || (!proof.IsOfAbsence() && proof.IsNonEmptyRange())) {
-				t.Errorf("expected proof of absence, or, an non-empty range proof, or, a single empty leaf for ns %x", ns)
-			}
-			if !proof.IsNonEmptyRange() && proof.IsOfAbsence() {
-				t.Fatalf("empty range can't be a proof of absence for a namespace")
-			}
-
-			if len(data) != 0 {
-				emptyProof := nmt.NewEmptyRangeProof(false)
-				if emptyProof.VerifyNamespace(hash, nid, data, treeRoot) {
-					t.Fatalf("empty range proof on non-empty data verified to true")
-				}
-				nonEmptyNsCount++
-			}
-		}
-		t.Logf("... with %v of %v namespaces non-empty.", nonEmptyNsCount, len(sortedKeys))
+	for seed := int64(0); seed < 5; seed++ {
+		f.Add(seed)
 	}
+	f.Fuzz(func(t *testing.T, seed int64) {
+		rng := rand.New(rand.NewSource(seed))
+		for _, nsSize := range []int{8, 16, 32} {
+			proveAndVerifyNamespaces(t, rng, nsSize)
+		}
+	})
 }
 
-func makeRandDataAndSortedKeys(size testNamespaceSizes, minNumOfNs, maxNumOfNs, minElemsPerNs, maxElemsPerNs int, emptyNsProb float64) (map[string][][]byte, []string) {
-	nidDataMap := make(map[string][][]byte)
-	f := makeFuzzer(size, minNumOfNs, maxNumOfNs, minElemsPerNs, maxElemsPerNs, emptyNsProb)
-	f.Fuzz(&nidDataMap)
-	keys := make([]string, len(nidDataMap))
-	idx := 0
+func proveAndVerifyNamespaces(t *testing.T, rng *rand.Rand, nsSize int) {
+	nidDataMap, sortedKeys := makeRandDataAndSortedKeys(rng, nsSize)
+	t.Logf("Generated %v namespaces for size: %v ...", len(nidDataMap), nsSize)
+	hash := sha256.New()
+	tree := nmt.New(hash, nmt.NamespaceIDSize(nsSize))
+
+	// push data in order:
+	for _, ns := range sortedKeys {
+		leafDataList := nidDataMap[ns]
+		for _, d := range leafDataList {
+			err := tree.Push(d)
+			if err != nil {
+				t.Fatalf("error on Push(): %v", err)
+			}
+		}
+	}
+
+	treeRoot, err := tree.Root()
+	require.NoError(t, err)
+	nonEmptyNsCount := 0
+	leafIdx := 0
+	for _, ns := range sortedKeys {
+		nid := namespace.ID(ns)
+		data := tree.Get(nid)
+		proof, err := tree.ProveNamespace(nid)
+		if err != nil {
+			t.Fatalf("error on ProveNamespace(%x): %v", ns, err)
+		}
+
+		if ok := proof.VerifyNamespace(hash, nid, data, treeRoot); !ok {
+			t.Fatalf("expected VerifyNamespace() == true")
+		}
+
+		// some sanity checks:
+		items := nidDataMap[ns]
+		if len(items) != len(data) {
+			t.Fatalf("returned number of items didn't match pushed number of items")
+		}
+		for i := 0; i < len(items); i++ {
+			if !reflect.DeepEqual(items[i], data[i]) {
+				t.Fatalf("returned data didn't match pushed data")
+			}
+			singleItemProof, err := tree.Prove(leafIdx)
+			if err != nil {
+				t.Fatalf("error on Prove(%v): %v", i, err)
+			}
+			if ok := singleItemProof.VerifyInclusion(hash, data[i][:nsSize], [][]byte{data[i][nsSize:]}, treeRoot); !ok {
+				t.Fatalf("expected VerifyInclusion() == true; data = %#v; proof = %#v", data[i], singleItemProof)
+			}
+			leafIdx++
+		}
+
+		isSingleLeaf := proof.End()-proof.Start() == 1
+		if len(data) == 0 && !isSingleLeaf &&
+			(proof.IsOfAbsence() || (!proof.IsOfAbsence() && proof.IsNonEmptyRange())) {
+			t.Errorf("expected proof of absence, or, an non-empty range proof, or, a single empty leaf for ns %x", ns)
+		}
+		if !proof.IsNonEmptyRange() && proof.IsOfAbsence() {
+			t.Fatalf("empty range can't be a proof of absence for a namespace")
+		}
+
+		if len(data) != 0 {
+			emptyProof := nmt.NewEmptyRangeProof(false)
+			if emptyProof.VerifyNamespace(hash, nid, data, treeRoot) {
+				t.Fatalf("empty range proof on non-empty data verified to true")
+			}
+			nonEmptyNsCount++
+		}
+	}
+	t.Logf("... with %v of %v namespaces non-empty.", nonEmptyNsCount, len(sortedKeys))
+}
+
+// makeRandDataAndSortedKeys generates a map of random namespaces to lists of
+// leaves (each leaf prefixed with its namespace), plus the namespace keys in
+// ascending order. Some namespaces are left empty so that proofs of absence
+// get exercised.
+func makeRandDataAndSortedKeys(rng *rand.Rand, nsSize int) (map[string][][]byte, []string) {
+	// The ranges are kept small enough that a single fuzz iteration completes
+	// in milliseconds; per-leaf proving is quadratic in the total leaf count,
+	// and iterations slower than a few seconds trip the fuzzer's hang
+	// detector.
+	const (
+		minNumberOfNamespaces = 4
+		maxNumberOfNamespaces = 16
+
+		minElementsPerNamespace = 0
+		maxElementsPerNamespace = 32
+
+		maxElementSize = 64
+
+		emptyNamespaceProbability = 0.15
+	)
+
+	numNamespaces := randRange(rng, minNumberOfNamespaces, maxNumberOfNamespaces)
+	nidDataMap := make(map[string][][]byte, numNamespaces)
+	for len(nidDataMap) < numNamespaces {
+		ns := make([]byte, nsSize)
+		rng.Read(ns)
+		if _, ok := nidDataMap[string(ns)]; ok {
+			continue
+		}
+		var leaves [][]byte
+		if rng.Float64() >= emptyNamespaceProbability {
+			leaves = make([][]byte, randRange(rng, minElementsPerNamespace, maxElementsPerNamespace))
+			for i := range leaves {
+				leaf := make([]byte, nsSize+rng.Intn(maxElementSize+1))
+				copy(leaf, ns)
+				rng.Read(leaf[nsSize:])
+				leaves[i] = leaf
+			}
+		}
+		nidDataMap[string(ns)] = leaves
+	}
+
+	keys := make([]string, 0, len(nidDataMap))
 	for k := range nidDataMap {
-		keys[idx] = k
-		idx++
+		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 	return nidDataMap, keys
 }
 
-type testNamespaceSizes int
-
-const (
-	size8  testNamespaceSizes = 8
-	size16 testNamespaceSizes = 16
-	size32 testNamespaceSizes = 32
-)
-
-func makeFuzzer(size testNamespaceSizes, minNumOfNs, maxNumOfNs, minElemsPerNs, maxElemsPerNs int, emptyNsProb float64) *fuzz.Fuzzer {
-	switch size {
-	case size8:
-		var lastNs [size8]byte
-		return fuzz.New().NilChance(0).NumElements(minNumOfNs, maxNumOfNs).Funcs(
-			func(s *string, c fuzz.Continue) {
-				// create a random namespace of size 8:
-				c.Fuzz(&lastNs)
-				*s = string(lastNs[:])
-			},
-			func(s *[][]byte, _ fuzz.Continue) {
-				var tmp [][]byte
-				f := fuzz.New().NilChance(emptyNsProb).NumElements(minElemsPerNs, maxElemsPerNs)
-				f.Fuzz(&tmp)
-				*s = make([][]byte, len(tmp))
-				for i, d := range tmp {
-					d = append(d[:0], lastNs[:]...)
-					(*s)[i] = d
-				}
-			})
-	case size16:
-		var lastNs [size16]byte
-		return fuzz.New().NilChance(0).NumElements(minNumOfNs, maxNumOfNs).Funcs(
-			func(s *string, c fuzz.Continue) {
-				// create a random namespace of size 16:
-				c.Fuzz(&lastNs)
-				*s = string(lastNs[:])
-			},
-			func(s *[][]byte, _ fuzz.Continue) {
-				var tmp [][]byte
-				f := fuzz.New().NilChance(emptyNsProb).NumElements(minElemsPerNs, maxElemsPerNs)
-				f.Fuzz(&tmp)
-				*s = make([][]byte, len(tmp))
-				for i, d := range tmp {
-					d = append(d[:0], lastNs[:]...)
-					(*s)[i] = d
-				}
-			})
-	case size32:
-		var lastNs [size32]byte
-		return fuzz.New().NilChance(0).NumElements(minNumOfNs, maxNumOfNs).Funcs(
-			func(s *string, c fuzz.Continue) {
-				// create a random namespace of size 32:
-				c.Fuzz(&lastNs)
-				*s = string(lastNs[:])
-			},
-			func(s *[][]byte, _ fuzz.Continue) {
-				var tmp [][]byte
-				f := fuzz.New().NilChance(emptyNsProb).NumElements(minElemsPerNs, maxElemsPerNs)
-				f.Fuzz(&tmp)
-				*s = make([][]byte, len(tmp))
-				for i, d := range tmp {
-					d = append(d[:0], lastNs[:]...)
-					(*s)[i] = d
-				}
-			})
-	}
-	panic("unsupported namespace size")
+// randRange returns a random int in the inclusive range [low, high].
+func randRange(rng *rand.Rand, low, high int) int {
+	return low + rng.Intn(high-low+1)
 }

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -13,28 +13,40 @@ import (
 	"github.com/celestiaorg/nmt/namespace"
 )
 
-// FuzzProveVerifyNamespace builds trees from randomly generated namespaces and
-// leaf data, then checks that namespace proofs and inclusion proofs for every
-// namespace verify against the root. The fuzzed seed drives a deterministic
-// random generator so that every failure is reproducible from its corpus
-// entry. Run with: go test -fuzz=FuzzProveVerifyNamespace
+// FuzzProveVerifyNamespace builds a tree from namespaces and leaf data parsed
+// out of the raw fuzz input, then checks that namespace proofs and inclusion
+// proofs for every namespace verify against the root. Parsing the input bytes
+// directly (rather than fuzzing a PRNG seed) lets the coverage-guided fuzzer
+// mutate the actual tree structure and leaf data.
+// Run with: go test -fuzz=FuzzProveVerifyNamespace
 func FuzzProveVerifyNamespace(f *testing.F) {
 	if testing.Short() {
 		f.Skip("FuzzProveVerifyNamespace skipped in short mode.")
 	}
-	for seed := int64(0); seed < 5; seed++ {
-		f.Add(seed)
-	}
-	f.Fuzz(func(t *testing.T, seed int64) {
-		rng := rand.New(rand.NewSource(seed))
-		for _, nsSize := range []int{8, 16, 32} {
-			proveAndVerifyNamespaces(t, rng, nsSize)
+	// Seed corpus: deterministic pseudo-random inputs covering every
+	// namespace size, plus the empty-tree edge case.
+	f.Add([]byte{})
+	rng := rand.New(rand.NewSource(1))
+	for sizeIdx := 0; sizeIdx < 3; sizeIdx++ {
+		for _, inputLen := range []int{64, 2048, 16384} {
+			seed := make([]byte, inputLen)
+			rng.Read(seed)
+			seed[0] = byte(sizeIdx)
+			f.Add(seed)
 		}
+	}
+	f.Fuzz(func(t *testing.T, input []byte) {
+		if len(input) == 0 {
+			return
+		}
+		nsSizes := []int{8, 16, 32}
+		nsSize := nsSizes[int(input[0])%len(nsSizes)]
+		proveAndVerifyNamespaces(t, input[1:], nsSize)
 	})
 }
 
-func proveAndVerifyNamespaces(t *testing.T, rng *rand.Rand, nsSize int) {
-	nidDataMap, sortedKeys := makeRandDataAndSortedKeys(rng, nsSize)
+func proveAndVerifyNamespaces(t *testing.T, input []byte, nsSize int) {
+	nidDataMap, sortedKeys := makeNsDataAndSortedKeys(input, nsSize)
 	t.Logf("Generated %v namespaces for size: %v ...", len(nidDataMap), nsSize)
 	hash := sha256.New()
 	tree := nmt.New(hash, nmt.NamespaceIDSize(nsSize))
@@ -77,7 +89,7 @@ func proveAndVerifyNamespaces(t *testing.T, rng *rand.Rand, nsSize int) {
 			}
 			singleItemProof, err := tree.Prove(leafIdx)
 			if err != nil {
-				t.Fatalf("error on Prove(%v): %v", i, err)
+				t.Fatalf("error on Prove(%v): %v", leafIdx, err)
 			}
 			if ok := singleItemProof.VerifyInclusion(hash, data[i][:nsSize], [][]byte{data[i][nsSize:]}, treeRoot); !ok {
 				t.Fatalf("expected VerifyInclusion() == true; data = %#v; proof = %#v", data[i], singleItemProof)
@@ -105,43 +117,41 @@ func proveAndVerifyNamespaces(t *testing.T, rng *rand.Rand, nsSize int) {
 	t.Logf("... with %v of %v namespaces non-empty.", nonEmptyNsCount, len(sortedKeys))
 }
 
-// makeRandDataAndSortedKeys generates a map of random namespaces to lists of
-// leaves (each leaf prefixed with its namespace), plus the namespace keys in
-// ascending order. Some namespaces are left empty so that proofs of absence
-// get exercised.
-func makeRandDataAndSortedKeys(rng *rand.Rand, nsSize int) (map[string][][]byte, []string) {
-	// The ranges are kept small enough that a single fuzz iteration completes
-	// in milliseconds; per-leaf proving is quadratic in the total leaf count,
-	// and iterations slower than a few seconds trip the fuzzer's hang
-	// detector.
+// makeNsDataAndSortedKeys parses the fuzz input into a map of namespaces to
+// lists of leaves (each leaf prefixed with its namespace), plus the namespace
+// keys in ascending order. Namespaces with a count byte below
+// emptyNamespaceThreshold are left empty so that proofs of absence get
+// exercised.
+func makeNsDataAndSortedKeys(input []byte, nsSize int) (map[string][][]byte, []string) {
+	// The caps keep a single fuzz iteration in the milliseconds range;
+	// per-leaf proving is quadratic in the total leaf count, and iterations
+	// slower than a few seconds trip the fuzzer's hang detector.
 	const (
-		minNumberOfNamespaces = 4
-		maxNumberOfNamespaces = 16
-
-		minElementsPerNamespace = 0
+		maxNumberOfNamespaces   = 16
 		maxElementsPerNamespace = 32
+		maxElementSize          = 64
 
-		maxElementSize = 64
-
-		emptyNamespaceProbability = 0.15
+		// ~15% of count bytes leave the namespace empty.
+		emptyNamespaceThreshold = 40
 	)
 
-	numNamespaces := randRange(rng, minNumberOfNamespaces, maxNumberOfNamespaces)
-	nidDataMap := make(map[string][][]byte, numNamespaces)
-	for len(nidDataMap) < numNamespaces {
-		ns := make([]byte, nsSize)
-		rng.Read(ns)
+	r := &byteReader{data: input}
+	nidDataMap := make(map[string][][]byte)
+	for len(nidDataMap) < maxNumberOfNamespaces && r.remaining() > 0 {
+		ns := r.read(nsSize)
 		if _, ok := nidDataMap[string(ns)]; ok {
 			continue
 		}
 		var leaves [][]byte
-		if rng.Float64() >= emptyNamespaceProbability {
-			leaves = make([][]byte, randRange(rng, minElementsPerNamespace, maxElementsPerNamespace))
-			for i := range leaves {
-				leaf := make([]byte, nsSize+rng.Intn(maxElementSize+1))
-				copy(leaf, ns)
-				rng.Read(leaf[nsSize:])
-				leaves[i] = leaf
+		if countByte := r.readByte(); countByte >= emptyNamespaceThreshold {
+			numLeaves := 1 + int(countByte)%maxElementsPerNamespace
+			leaves = make([][]byte, 0, numLeaves)
+			for i := 0; i < numLeaves; i++ {
+				payloadLen := int(r.readByte()) % (maxElementSize + 1)
+				leaf := make([]byte, 0, nsSize+payloadLen)
+				leaf = append(leaf, ns...)
+				leaf = append(leaf, r.read(payloadLen)...)
+				leaves = append(leaves, leaf)
 			}
 		}
 		nidDataMap[string(ns)] = leaves
@@ -155,7 +165,23 @@ func makeRandDataAndSortedKeys(rng *rand.Rand, nsSize int) (map[string][][]byte,
 	return nidDataMap, keys
 }
 
-// randRange returns a random int in the inclusive range [low, high].
-func randRange(rng *rand.Rand, low, high int) int {
-	return low + rng.Intn(high-low+1)
+// byteReader hands out chunks of the fuzz input, zero-padding once the input
+// is exhausted so parsing never fails mid-structure.
+type byteReader struct {
+	data []byte
+}
+
+func (r *byteReader) remaining() int {
+	return len(r.data)
+}
+
+func (r *byteReader) readByte() byte {
+	return r.read(1)[0]
+}
+
+func (r *byteReader) read(n int) []byte {
+	out := make([]byte, n)
+	m := copy(out, r.data)
+	r.data = r.data[m:]
+	return out
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.23
 
 require (
 	github.com/gogo/protobuf v1.3.2
-	github.com/google/gofuzz v1.2.0
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/gjson v1.19.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
-github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
Closes #60

Replaces the `github.com/google/gofuzz`-based `TestFuzzProveVerifyNameSpace` with a native Go fuzz target, `FuzzProveVerifyNamespace`, and removes the gofuzz dependency.

- The target parses the raw fuzz input directly: the first byte selects the namespace size (8/16/32) and the remaining bytes are decoded into namespaces, leaf counts, and payloads via a zero-padding byte reader — so coverage-guided mutations map to structural changes in the tree. Run with `go test -fuzz=FuzzProveVerifyNamespace`; plain `go test` runs the deterministic seed corpus (all three namespace sizes plus the empty-tree case) in milliseconds.
- Leaves now carry random payloads — the gofuzz version's `append(d[:0], lastNs[:]...)` truncated every leaf to just its namespace bytes, so payloads were never exercised.
- Generation caps keep one iteration in the milliseconds range (per-leaf proving is quadratic in leaf count; slower iterations trip the fuzzer's hang detector).

Verified: full suite green, 60s fuzz run with no failures, and the target fails as expected when the root is deliberately corrupted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)