### PR TITLE
docs: document proof format and add runnable verification examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ The above will create a Namespaced merkle tree with four leafs which looks like 
 
 Where `nid_0 = nid_1 = 0` and `nid_2 = nid_3 = 1` and `data_i = "leaf_i"` for `i = 0,...,3`.
 
+## Documentation
+
+- [NMT library guide](docs/nmt-lib.md): how to construct an NMT and generate and verify proofs using this library.
+- [NMT specification](docs/spec/nmt.md): the NMT data structure and the proof generation and verification logic.
+- [NMT proof format](docs/proof-format.md): the exact format of NMT proofs, their serialization, and how to verify them.
+
 ## Related
 
 This implementation was heavily inspired by the initial implementation in [celestiaorg/lazyledger-prototype](https://github.com/celestiaorg/lazyledger-prototype).

--- a/docs/nmt-lib.md
+++ b/docs/nmt-lib.md
@@ -184,6 +184,8 @@ In the example given earlier, each node is `34` bytes in length and takes the fo
 
 `isMaxNamespaceIDIgnored`: If this field is true, then namespace range of the tree nodes are set as explained in the [Ignore Max Namespace](#ignore-max-namespace) section.
 
+For a precise description of the proof format, including the exact ordering of the proof `nodes` and how proofs are serialized, see [NMT Proof Format](./proof-format.md).
+
 ## Verify Namespace Proof
 
 The correctness of a namespace `Proof` for a specific namespace ID `nID` can be verified using the [`VerifyNamespace`](https://github.com/celestiaorg/nmt/blob/main/proof.go) method.

--- a/docs/proof-format.md
+++ b/docs/proof-format.md
@@ -140,7 +140,8 @@ The recomputation consumes `nodes` from front to back while recursing through th
 ```text
 computeRoot(rangeStart, rangeEnd):
   // if the current subtree does not overlap the proof range, it is covered
-  // by the next unconsumed proof node
+  // by the next unconsumed proof node; popFront returns nil if the proof
+  // nodes are exhausted, meaning the subtree does not exist in the tree
   if rangeEnd <= proof.start or rangeStart >= proof.end:
     return popFront(proof.nodes)
 
@@ -151,6 +152,12 @@ computeRoot(rangeStart, rangeEnd):
   k = largest power of two strictly smaller than (rangeEnd - rangeStart)
   left  = computeRoot(rangeStart, rangeStart + k)
   right = computeRoot(rangeStart + k, rangeEnd)
+
+  // when the number of leaves in the tree is not a power of two, subtrees
+  // near the end of the tree may not exist; only the right subtree can be
+  // non-existent
+  if right is nil:
+    return left
   return NsH(0x01, left, right)
 
 size = smallest power of two >= proof.end

--- a/docs/proof-format.md
+++ b/docs/proof-format.md
@@ -1,0 +1,165 @@
+# NMT Proof Format
+
+This document describes the exact format of the proofs produced by this library: what the fields of a proof mean, how the proof nodes are ordered, and how a proof is serialized.
+It also shows how to verify a proof using the Go implementation.
+For a conceptual explanation of how proofs are generated and verified, see the [NMT specification](./spec/nmt.md) and the [NMT library guide](./nmt-lib.md).
+
+## Proof structure
+
+A [`Proof`](../proof.go) proves the inclusion (or absence) of the leaves in the index range `[start, end)` under an NMT root.
+It consists of the following fields:
+
+| Field                     | Type       | Description                                                                                                                                                                |
+|---------------------------|------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `start`                   | `int`      | Index of the first leaf covered by the proof (inclusive).                                                                                                                  |
+| `end`                     | `int`      | Index one past the last leaf covered by the proof (exclusive).                                                                                                             |
+| `nodes`                   | `[][]byte` | The tree nodes needed, together with the leaves in `[start, end)`, to recompute the root. See [ordering of proof nodes](#ordering-of-proof-nodes).                         |
+| `leafHash`                | `[]byte`   | Empty for inclusion proofs. For [absence proofs](./spec/nmt.md#namespace-absence-proof), the hash of the leaf occupying the position where the queried namespace would be. |
+| `isMaxNamespaceIDIgnored` | `bool`     | Whether the tree was built with the [Ignore Max Namespace](./nmt-lib.md#ignore-max-namespace) option. Celestia sets this to `true`.                                        |
+
+An empty proof (`start = end = 0` and no `nodes`) is returned when the queried namespace falls outside the namespace range of the root (see [namespace empty proof](./spec/nmt.md#namespace-empty-proof)).
+
+### Node format
+
+Every entry of `nodes`, as well as `leafHash` and the root itself, is a **namespaced hash** of the form:
+
+```text
+minNs || maxNs || digest
+```
+
+where `minNs` and `maxNs` are the minimum and maximum namespace IDs of all the leaves under that node (each of size `NamespaceSize` bytes), and `digest` is the output of the underlying hash function (32 bytes for SHA256).
+For example, with SHA256 and Celestia's 29-byte namespaces, every node is `29 + 29 + 32 = 90` bytes.
+Leaf and inner digests are domain-separated with a `0x00` or `0x01` prefix, respectively, in accordance with [RFC 6962](https://www.rfc-editor.org/rfc/rfc6962#section-2.1); see the [namespaced hash specification](./spec/nmt.md#namespaced-hash) for the exact hash calculation.
+
+## Ordering of proof nodes
+
+`nodes` contains the roots of the maximal subtrees that do not overlap the proven range `[start, end)` but are needed to recompute the root.
+These are the siblings along the paths connecting the proven range to the root:
+
+- the left siblings of the branch connecting the `start` leaf to the root, and
+- the right siblings of the branch connecting the `end - 1` leaf to the root.
+
+The nodes are ordered according to an **in-order traversal** of the tree (not preorder or postorder).
+Equivalently, they are sorted in ascending order of the leaf indices they cover: the left siblings appear first, in root-to-leaf order, followed by the right siblings in leaf-to-root order.
+
+For example, consider an 8-leaf NMT and a proof for the leaf range `[4, 6)`.
+Each internal node below is labeled with the range of leaves it covers:
+
+```text
+                 [0,8) (root)
+               /        \
+          [0,4)          [4,8)
+         /      \       /      \
+      [0,2)  [2,4)   [4,6)    [6,8)
+      /  \    /  \    /  \     /  \
+     0    1  2    3  4    5   6    7
+```
+
+The proof consists of `nodes = [hash([0,4)), hash([6,8))]`: first the subtree covering leaves 0–3 (the only left sibling), then the subtree covering leaves 6–7 (the only right sibling).
+Note that only these maximal subtree roots are included, not the individual leaf hashes underneath them.
+
+As a concrete example, consider the 4-leaf tree of [Figure 1 in the specification](./spec/nmt.md#namespaced-hash), which has leaves with namespaces `0, 0, 1, 3` and a namespace size of 1 byte.
+The namespace proof for namespace `1` covers the range `[2, 3)` and contains:
+
+```text
+nodes[0] = 00 00 ead8d25...  (root of the subtree covering leaves 0-1, the left sibling)
+nodes[1] = 03 03 b4a2792...  (leaf hash of leaf 3, the right sibling)
+```
+
+The runnable example `ExampleProof_VerifyNamespace` in [example_test.go](../example_test.go) reproduces exactly this proof.
+
+## Serialization
+
+Proofs are serialized using the [`pb.Proof`](../pb/proof.proto) protobuf message:
+
+```proto
+message Proof {
+  int64 start = 1;
+  int64 end = 2;
+  repeated bytes nodes = 3;
+  bytes leaf_hash = 4;
+  bool is_max_namespace_ignored = 5;
+}
+```
+
+`Proof` implements `json.Marshaler` and `json.Unmarshaler` by encoding this protobuf message with Go's `encoding/json`. Consequently:
+
+- The JSON keys are `start`, `end`, `nodes`, `leaf_hash`, and `is_max_namespace_ignored`.
+- Byte fields (`nodes` entries and `leaf_hash`) are standard base64-encoded strings.
+- Zero-valued fields are omitted. For example, `leaf_hash` is absent for inclusion proofs, and `start` is absent when it is `0`.
+
+The namespace proof for namespace `1` from the example above serializes to:
+
+```json
+{
+  "start": 2,
+  "end": 3,
+  "nodes": [
+    "AADq2NJYUYcOTntejk0QCS30laDXOvb+w3Cax5+mM49Xrg==",
+    "AwO0onki2V6R1KVmqq3O31AmtiACJxWRCjVBhMCvOE4UQA=="
+  ],
+  "is_max_namespace_ignored": true
+}
+```
+
+## Verifying a proof
+
+### Using this library
+
+The library provides the following verification methods, all defined on `Proof` in [proof.go](../proof.go):
+
+| Method                       | Use it when                                                                                                                                                                                                     |
+|------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `VerifyNamespace`            | You have a namespace proof (from `ProveNamespace`) and the complete set of namespace-prefixed leaves for that namespace. Verifies inclusion and completeness, and handles absence and empty proofs.             |
+| `VerifyInclusion`            | You have an index-based proof (from `Prove` or `ProveRange`) and the raw leaf data **without** namespace prefixes, all sharing a single namespace. Does not verify completeness.                                |
+| `VerifyLeafHashes`           | Like `VerifyInclusion`, but takes leaf hashes instead of raw leaves, and optionally verifies completeness.                                                                                                      |
+| `VerifySubtreeRootInclusion` | Celestia-specific: you have subtree roots (per [ADR-013](https://github.com/celestiaorg/celestia-app/blob/main/docs/architecture/adr-013-non-interactive-default-rules-for-zero-padding.md)) instead of leaves. |
+
+For instance, verifying the inclusion of a single raw leaf by index:
+
+```go
+tree := nmt.New(sha256.New(), nmt.NamespaceIDSize(1))
+// push the namespace-prefixed leaves of Figure 1 and compute the root, then:
+proof, err := tree.Prove(2)
+if err != nil {
+  panic(err)
+}
+rawLeaves := [][]byte{[]byte("leaf_2")} // leaf data without the namespace prefix
+if proof.VerifyInclusion(sha256.New(), namespace.ID{1}, rawLeaves, root) {
+  fmt.Println("proof is valid")
+}
+```
+
+Complete runnable examples are provided in [example_test.go](../example_test.go) and rendered on [pkg.go.dev](https://pkg.go.dev/github.com/celestiaorg/nmt#pkg-examples).
+
+### Reimplementing verification
+
+To verify a proof without this library, recompute the root from the leaf hashes in `[start, end)` and the proof `nodes`, and compare it to the expected root.
+The recomputation consumes `nodes` from front to back while recursing through the tree (this mirrors `computeRoot` in [proof.go](../proof.go)):
+
+```text
+computeRoot(rangeStart, rangeEnd):
+  // if the current subtree does not overlap the proof range, it is covered
+  // by the next unconsumed proof node
+  if rangeEnd <= proof.start or rangeStart >= proof.end:
+    return popFront(proof.nodes)
+
+  // a leaf inside the proof range is the next unconsumed leaf hash
+  if rangeEnd - rangeStart == 1:
+    return popFront(leafHashes)
+
+  k = largest power of two strictly smaller than (rangeEnd - rangeStart)
+  left  = computeRoot(rangeStart, rangeStart + k)
+  right = computeRoot(rangeStart + k, rangeEnd)
+  return NsH(0x01, left, right)
+
+size = smallest power of two >= proof.end
+root = computeRoot(0, size)
+// any remaining proof nodes are roots of subtrees covering leaves at
+// indices >= size, ordered from leaf to root
+while proof.nodes is not fully consumed:
+  root = NsH(0x01, root, popFront(proof.nodes))
+```
+
+where `NsH` is the [namespaced hash function](./spec/nmt.md#namespaced-hash) and each leaf hash is computed as `NsH(0x00, namespace || leafData)`.
+Namespace proofs additionally require the completeness and absence checks described in [namespace proof verification](./spec/nmt.md#namespace-proof-verification).

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,123 @@
+package nmt_test
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+
+	"github.com/celestiaorg/nmt"
+	"github.com/celestiaorg/nmt/namespace"
+)
+
+// ExampleProof_VerifyNamespace generates a namespace proof for the tree shown
+// in Figure 1 of docs/spec/nmt.md and verifies it. The two proof nodes are the
+// namespaced hashes of the subtree covering leaves 0-1 (the left sibling of
+// the branch connecting leaf 2 to the root) and of leaf 3 (the right sibling),
+// ordered by an in-order traversal of the tree. See docs/proof-format.md for
+// details on the proof format.
+func ExampleProof_VerifyNamespace() {
+	// leaves are prefixed with their namespace ID before being pushed
+	leaves := [][]byte{
+		append(namespace.ID{0}, []byte("leaf_0")...),
+		append(namespace.ID{0}, []byte("leaf_1")...),
+		append(namespace.ID{1}, []byte("leaf_2")...),
+		append(namespace.ID{3}, []byte("leaf_3")...),
+	}
+	tree := nmt.New(sha256.New(), nmt.NamespaceIDSize(1))
+	for _, leaf := range leaves {
+		if err := tree.Push(leaf); err != nil {
+			panic(err)
+		}
+	}
+	root, err := tree.Root()
+	if err != nil {
+		panic(err)
+	}
+
+	nID := namespace.ID{1}
+	proof, err := tree.ProveNamespace(nID)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("proof range: [%d, %d)\n", proof.Start(), proof.End())
+	for i, node := range proof.Nodes() {
+		fmt.Printf("proof node %d: %x\n", i, node)
+	}
+
+	// verification requires the complete set of leaves (namespace-prefixed)
+	// that match the queried namespace ID
+	valid := proof.VerifyNamespace(sha256.New(), nID, leaves[proof.Start():proof.End()], root)
+	fmt.Printf("valid: %v\n", valid)
+	// Output:
+	// proof range: [2, 3)
+	// proof node 0: 0000ead8d25851870e4e7b5e8e4d10092df495a0d73af6fec3709ac79fa6338f57ae
+	// proof node 1: 0303b4a27922d95e91d4a566aaadcedf5026b620022715910a354184c0af384e1440
+	// valid: true
+}
+
+// ExampleProof_VerifyInclusion generates an index-based Merkle inclusion proof
+// for the leaf at index 2 of the tree shown in Figure 1 of docs/spec/nmt.md
+// and verifies it against the root. Note that VerifyInclusion takes the raw
+// leaf data without the namespace prefix.
+func ExampleProof_VerifyInclusion() {
+	leaves := [][]byte{
+		append(namespace.ID{0}, []byte("leaf_0")...),
+		append(namespace.ID{0}, []byte("leaf_1")...),
+		append(namespace.ID{1}, []byte("leaf_2")...),
+		append(namespace.ID{3}, []byte("leaf_3")...),
+	}
+	tree := nmt.New(sha256.New(), nmt.NamespaceIDSize(1))
+	for _, leaf := range leaves {
+		if err := tree.Push(leaf); err != nil {
+			panic(err)
+		}
+	}
+	root, err := tree.Root()
+	if err != nil {
+		panic(err)
+	}
+
+	proof, err := tree.Prove(2)
+	if err != nil {
+		panic(err)
+	}
+
+	// the leaf data is provided without the namespace prefix; the namespace ID
+	// is passed separately and applies to all leaves in the proof range
+	rawLeaves := [][]byte{[]byte("leaf_2")}
+	valid := proof.VerifyInclusion(sha256.New(), namespace.ID{1}, rawLeaves, root)
+	fmt.Printf("valid: %v\n", valid)
+	// Output:
+	// valid: true
+}
+
+// ExampleProof_MarshalJSON shows the JSON serialization of a namespace proof.
+// Nodes are base64-encoded namespaced hashes and zero-valued fields are
+// omitted. See docs/proof-format.md for details.
+func ExampleProof_MarshalJSON() {
+	leaves := [][]byte{
+		append(namespace.ID{0}, []byte("leaf_0")...),
+		append(namespace.ID{0}, []byte("leaf_1")...),
+		append(namespace.ID{1}, []byte("leaf_2")...),
+		append(namespace.ID{3}, []byte("leaf_3")...),
+	}
+	tree := nmt.New(sha256.New(), nmt.NamespaceIDSize(1))
+	for _, leaf := range leaves {
+		if err := tree.Push(leaf); err != nil {
+			panic(err)
+		}
+	}
+
+	proof, err := tree.ProveNamespace(namespace.ID{1})
+	if err != nil {
+		panic(err)
+	}
+
+	data, err := json.Marshal(proof)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%s\n", data)
+	// Output:
+	// {"start":2,"end":3,"nodes":["AADq2NJYUYcOTntejk0QCS30laDXOvb+w3Cax5+mM49Xrg==","AwO0onki2V6R1KVmqq3O31AmtiACJxWRCjVBhMCvOE4UQA=="],"is_max_namespace_ignored":true}
+}


### PR DESCRIPTION
Closes https://github.com/celestiaorg/nmt/issues/248

## Overview

The proof format returned by this library was not precisely documented, making it hard to verify proofs (especially outside Go). This PR:

- Adds [docs/proof-format.md](https://github.com/celestiaorg/nmt/blob/rp/document-proof-format/docs/proof-format.md) documenting the `Proof` fields, the exact ordering of proof `nodes` (in-order traversal, answering the question in the issue), the namespaced-hash node format, the protobuf/JSON serialization, and pseudo-code for recomputing the root when reimplementing verification (including trees whose leaf count is not a power of two).
- Adds `example_test.go` with runnable, CI-tested `Example` functions demonstrating `VerifyNamespace`, `VerifyInclusion`, and the JSON wire format. These render on [pkg.go.dev](https://pkg.go.dev/github.com/celestiaorg/nmt#pkg-examples).
- Links the docs from the README and `docs/nmt-lib.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)