### PR TITLE
docs: clarify ComputeSubtreeRoot range

### DIFF
--- a/nmt.go
+++ b/nmt.go
@@ -704,9 +704,7 @@ func (n *NamespacedMerkleTree) updateMinMaxID(id namespace.ID) {
 	}
 }
 
-// ComputeSubtreeRoot takes a leaf range and returns the corresponding subtree root.
-// Also, it requires the start and end range to correctly reference an inner node.
-// The provided range, defined by start and end, is end-exclusive.
+// ComputeSubtreeRoot returns the subtree root for the leaf range [start, end).
 func (n *NamespacedMerkleTree) ComputeSubtreeRoot(start, end int) ([]byte, error) {
 	if start < 0 {
 		return nil, fmt.Errorf("start %d shouldn't be strictly negative", start)


### PR DESCRIPTION
Closes #266.

Clarify that `ComputeSubtreeRoot` accepts an end-exclusive range of leaf indices, `[start, end)`. The previous wording implied that the indices themselves referenced an inner node, which was the ambiguity called out in the original review.

### Validation

- `go test ./...`
- `go test -race ./... -skip ^'Test_Root_RaceCondition$'` (the excluded test is the independently tracked race in #338)\n- `go vet ./...`\n- `golangci-lint run`\n- `docker run --rm -v "$PWD:/workspace" -w /workspace golang:1.27 go test ./...`