### PR TITLE
proof: clarify empty range proof validation

### DIFF
--- a/proof.go
+++ b/proof.go
@@ -142,33 +142,43 @@ func (proof Proof) IsEmptyProof() bool {
 	return proof.start == proof.end && len(proof.nodes) == 0 && len(proof.leafHash) == 0
 }
 
-func (proof Proof) isValidEmptyRangeProof(nth *NmtHasher, nID namespace.ID, root []byte, leaves [][]byte, checkNS bool) bool {
-	if !proof.IsEmptyProof() || len(leaves) != 0 {
+func (proof Proof) isValidEmptyRangeProof(
+	nth *NmtHasher,
+	nID namespace.ID,
+	root []byte,
+	leaves [][]byte,
+	verifyNamespaceRange bool,
+) bool {
+	if !proof.IsEmptyProof() {
+		return false
+	}
+	if len(leaves) != 0 {
 		return false
 	}
 
-	if !checkNS {
+	// VerifyInclusion does not make a completeness claim, so an empty proof and
+	// empty leaf range are sufficient there. VerifyNamespace additionally has
+	// to prove that the namespace cannot occur in the tree.
+	if !verifyNamespaceRange {
 		return true
 	}
+	return isEmptyRootOrNamespaceOutsideRange(nth, nID, root)
+}
 
-	// validate the root format before slicing its namespace bounds below.
-	// Without this check, a root shorter than 2*nID.Size() would cause
-	// MinNamespace/MaxNamespace to panic with a slice bounds error instead of
-	// returning a verification failure. The non-empty path performs the
-	// equivalent validation via nth.ValidateNodeFormat(root) in VerifyLeafHashes.
+func isEmptyRootOrNamespaceOutsideRange(nth *NmtHasher, nID namespace.ID, root []byte) bool {
+	// Validate before slicing the namespace bounds. The non-empty path performs
+	// the equivalent validation in VerifyLeafHashes.
 	if err := nth.ValidateNodeFormat(root); err != nil {
 		return false
+	}
+	if bytes.Equal(root, nth.EmptyRoot()) {
+		return true
 	}
 
 	nIDLen := nID.Size()
 	rootMin := namespace.ID(MinNamespace(root, nIDLen))
 	rootMax := namespace.ID(MaxNamespace(root, nIDLen))
-
-	// empty proofs are always rejected unless 1) nID is outside the range of
-	// namespaces covered by the root 2) the root represents an empty tree, since
-	// it purports to cover the zero namespace but does not actually include
-	// any such nodes
-	return nID.Less(rootMin) || rootMax.Less(nID) || bytes.Equal(root, nth.EmptyRoot())
+	return nID.Less(rootMin) || rootMax.Less(nID)
 }
 
 // ComputeAndValidateLeafHashes validates and hashes a list of leaves using the provided NMT hasher.

--- a/proof_test.go
+++ b/proof_test.go
@@ -125,6 +125,59 @@ func TestVerifyNamespace_EmptyProofShortRoot(t *testing.T) {
 	})
 }
 
+func TestVerifyNamespace_EmptyProofRangeBoundaries(t *testing.T) {
+	tree := exampleNMT(1, true, 1, 2, 3, 4)
+	root, err := tree.Root()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		nID  namespace.ID
+		root []byte
+		want bool
+	}{
+		{name: "below minimum", nID: namespace.ID{0}, root: root, want: true},
+		{name: "at minimum", nID: namespace.ID{1}, root: root},
+		{name: "inside range", nID: namespace.ID{2}, root: root},
+		{name: "at maximum", nID: namespace.ID{4}, root: root},
+		{name: "above maximum", nID: namespace.ID{5}, root: root, want: true},
+		{name: "empty tree", nID: namespace.ID{0}, root: tree.treeHasher.EmptyRoot(), want: true},
+		{name: "malformed root", nID: namespace.ID{0}, root: []byte{1}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			proof := NewEmptyRangeProof(true)
+			require.Equal(t, tt.want, proof.VerifyNamespace(sha256.New(), tt.nID, nil, tt.root))
+		})
+	}
+}
+
+func TestVerifyInclusion_EmptyProofStructure(t *testing.T) {
+	tree := exampleNMT(1, true, 1, 2, 3, 4)
+	root, err := tree.Root()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name   string
+		proof  Proof
+		leaves [][]byte
+		want   bool
+	}{
+		{name: "empty proof and nil leaves", proof: NewEmptyRangeProof(true), want: true},
+		{name: "empty proof and empty leaves", proof: NewEmptyRangeProof(true), leaves: [][]byte{}, want: true},
+		{name: "non-empty leaves", proof: NewEmptyRangeProof(true), leaves: [][]byte{{1}}},
+		{name: "proof node", proof: Proof{start: 0, end: 0, nodes: [][]byte{{1}}, isMaxNamespaceIDIgnored: true}},
+		{name: "absence leaf hash", proof: Proof{start: 0, end: 0, leafHash: []byte{1}, isMaxNamespaceIDIgnored: true}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.proof.VerifyInclusion(sha256.New(), namespace.ID{1}, tt.leaves, root))
+		})
+	}
+}
+
 func TestProof_VerifyNamespace_False(t *testing.T) {
 	const testNidLen = 3
 


### PR DESCRIPTION
Closes #292

## Summary
- separate empty-proof structure checks from namespace-range validation
- make the different `VerifyNamespace` and `VerifyInclusion` guarantees explicit
- cover minimum/maximum boundaries, below/above range, empty trees, malformed roots, and invalid proof structure

## Validation
- `go test ./... -count=1`
- `go test -race . -run 'TestVerifyNamespace_EmptyProof|TestVerifyInclusion_EmptyProof' -count=1`
- `golangci-lint run`

A full repository `-race` run still reproduces the pre-existing `NamespacedMerkleTree.Root` race tracked in #338; the changed path passes under the race detector.