### PR TITLE
fix: synchronize root cache initialization

### DIFF
--- a/nmt.go
+++ b/nmt.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"hash"
 	"math/bits"
+	"sync"
 	"unsafe"
 
 	"github.com/celestiaorg/nmt/namespace"
@@ -132,6 +133,7 @@ type NamespacedMerkleTree struct {
 	// rawRoot caches the value of the tree root whenever the Root() method is
 	// invoked. It's important to note that rawRoot may become outdated and may
 	// not accurately reflect the current state of the leaves.
+	rootMu  sync.RWMutex
 	rawRoot []byte
 }
 
@@ -517,20 +519,34 @@ func (n *NamespacedMerkleTree) Push(namespacedData namespace.PrefixedData) error
 // been added through the use of the Push method. the returned byte slice is of
 // size 2* n.NamespaceSize + the underlying hash output size, and should be
 // parsed as minND || maxNID || hash
+// Root may be called concurrently with other Root calls after all leaves have
+// been added. It must not be called concurrently with methods that modify the
+// tree, such as Push, ForceAddLeaf, or Reset.
 // Any error returned by this method is irrecoverable and indicate an illegal state of the tree (n).
 func (n *NamespacedMerkleTree) Root() ([]byte, error) {
-	if n.rawRoot == nil {
-		res, err := n.computeRoot(0, n.Size())
-		if err != nil {
-			return nil, err // this should never happen since leaves are validated in the Push method
-		}
-		if n.reuseBuffers {
-			// we will reuse root's bytes, so we copy
-			n.rawRoot = make([]byte, len(res))
-			copy(n.rawRoot, res)
-		} else {
-			n.rawRoot = res
-		}
+	n.rootMu.RLock()
+	root := n.rawRoot
+	n.rootMu.RUnlock()
+	if root != nil {
+		return root, nil
+	}
+
+	n.rootMu.Lock()
+	defer n.rootMu.Unlock()
+	if n.rawRoot != nil {
+		return n.rawRoot, nil
+	}
+
+	res, err := n.computeRoot(0, n.Size())
+	if err != nil {
+		return nil, err // this should never happen since leaves are validated in the Push method
+	}
+	if n.reuseBuffers {
+		// we will reuse root's bytes, so we copy
+		n.rawRoot = make([]byte, len(res))
+		copy(n.rawRoot, res)
+	} else {
+		n.rawRoot = res
 	}
 	return n.rawRoot, nil
 }

--- a/nmt_test.go
+++ b/nmt_test.go
@@ -735,24 +735,45 @@ func BenchmarkComputeRoot(b *testing.B) {
 func Test_Root_RaceCondition(t *testing.T) {
 	// this is very similar to: https://github.com/HuobiRDCenter/huobi_Golang/pull/9
 	tree := New(sha256.New())
-	_ = tree.Push([]byte("some data is good enough here"))
+	require.NoError(t, tree.Push([]byte("some data is good enough here")))
+
 	numRoutines := 200
-	wg := sync.WaitGroup{}
+	start := make(chan struct{})
+	results := make(chan []byte, numRoutines)
+	errs := make(chan error, numRoutines)
+	var wg sync.WaitGroup
 	wg.Add(numRoutines)
 	for i := 0; i < numRoutines; i++ {
 		go func() {
-			defer func() {
-				if r := recover(); r != nil {
-					t.Errorf("race condition: panic %s", r)
-				}
-				wg.Done()
-			}()
-			_, err := tree.Root()
-			require.NoError(t, err)
+			defer wg.Done()
+			<-start
+			root, err := tree.Root()
+			if err != nil {
+				errs <- err
+				return
+			}
+			results <- root
 		}()
 	}
 
+	close(start)
 	wg.Wait()
+	close(results)
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	var expected []byte
+	for root := range results {
+		if expected == nil {
+			expected = root
+			continue
+		}
+		require.Equal(t, expected, root)
+	}
+	require.NotNil(t, expected)
 }
 
 func shouldPanic(t *testing.T, f func()) {


### PR DESCRIPTION
## Overview

- synchronize lazy root cache initialization so concurrent Root calls do not race through the shared hasher or cache
- keep a read-locked fast path for an already cached root
- strengthen the existing concurrent regression with a simultaneous start barrier and result equality checks
- document that concurrent Root calls are supported after tree mutation is complete

Closes #338

## Verification

- GOCACHE=/private/tmp/nmt-go-build GOMODCACHE=/private/tmp/nmt-go-mod go test -race ./...
- GOCACHE=/private/tmp/nmt-go-build GOMODCACHE=/private/tmp/nmt-go-mod go vet ./...
- git diff --check